### PR TITLE
Removed allocations

### DIFF
--- a/src/Paseto/Cryptography/Internal/ByteIntegerConverter.cs
+++ b/src/Paseto/Cryptography/Internal/ByteIntegerConverter.cs
@@ -1,245 +1,244 @@
-﻿using System;
+﻿namespace Paseto.Cryptography.Internal;
 
-namespace Paseto.Cryptography.Internal
+using System;
+
+// Loops? Arrays? Never heard of that stuff
+// Library avoids unnecessary heap allocations and unsafe code
+// so this ugly code becomes necessary :(
+internal static class ByteIntegerConverter
 {
-    // Loops? Arrays? Never heard of that stuff
-    // Library avoids unnecessary heap allocations and unsafe code
-    // so this ugly code becomes necessary :(
-    internal static class ByteIntegerConverter
+    #region Individual
+
+    /// <summary>
+    /// Loads 4 bytes of the input buffer into an unsigned 32-bit integer, beginning at the input offset.
+    /// </summary>
+    /// <param name="buf">The input buffer.</param>
+    /// <param name="offset">The input offset.</param>
+    /// <returns>System.UInt32.</returns>
+    public static uint LoadLittleEndian32(Span<byte> buf, int offset)
     {
-        #region Individual
-
-        /// <summary>
-        /// Loads 4 bytes of the input buffer into an unsigned 32-bit integer, beginning at the input offset.
-        /// </summary>
-        /// <param name="buf">The input buffer.</param>
-        /// <param name="offset">The input offset.</param>
-        /// <returns>System.UInt32.</returns>
-        public static uint LoadLittleEndian32(Span<byte> buf, int offset)
-        {
-            return
-                (uint)(buf[offset + 0])
-                | (((uint)(buf[offset + 1])) << 8)
-                | (((uint)(buf[offset + 2])) << 16)
-                | (((uint)(buf[offset + 3])) << 24);
-        }
-
-        /// <summary>
-        /// Stores the value into the buffer.
-        /// The value will be split into 4 bytes and put into four sequential places in the output buffer, starting at the specified offset.
-        /// </summary>
-        /// <param name="buf">The output buffer.</param>
-        /// <param name="offset">The output offset.</param>
-        /// <param name="value">The input value.</param>
-        public static void StoreLittleEndian32(byte[] buf, int offset, uint value)
-        {
-            buf[offset + 0] = unchecked((byte)value);
-            buf[offset + 1] = unchecked((byte)(value >> 8));
-            buf[offset + 2] = unchecked((byte)(value >> 16));
-            buf[offset + 3] = unchecked((byte)(value >> 24));
-        }
-
-        /// <summary>
-        /// Stores the value into the buffer.
-        /// The value will be split into 8 bytes and put into eight sequential places in the output buffer, starting at the specified offset.
-        /// </summary>
-        /// <param name="buf">The output buffer.</param>
-        /// <param name="offset">The output offset.</param>
-        /// <param name="value">The input value.</param>
-        public static void StoreLittleEndian64(byte[] buf, int offset, ulong value)
-        {
-            StoreLittleEndian32(buf, offset, (uint)value);
-            StoreLittleEndian32(buf, offset + 4, (uint)(value >> 32));
-        }
-
-        public static ulong LoadBigEndian64(byte[] buf, int offset)
-        {
-            return
-                (ulong)(buf[offset + 7])
-                | (((ulong)(buf[offset + 6])) << 8)
-                | (((ulong)(buf[offset + 5])) << 16)
-                | (((ulong)(buf[offset + 4])) << 24)
-                | (((ulong)(buf[offset + 3])) << 32)
-                | (((ulong)(buf[offset + 2])) << 40)
-                | (((ulong)(buf[offset + 1])) << 48)
-                | (((ulong)(buf[offset + 0])) << 56);
-        }
-
-        public static void StoreBigEndian64(byte[] buf, int offset, ulong value)
-        {
-            buf[offset + 7] = unchecked((byte)value);
-            buf[offset + 6] = unchecked((byte)(value >> 8));
-            buf[offset + 5] = unchecked((byte)(value >> 16));
-            buf[offset + 4] = unchecked((byte)(value >> 24));
-            buf[offset + 3] = unchecked((byte)(value >> 32));
-            buf[offset + 2] = unchecked((byte)(value >> 40));
-            buf[offset + 1] = unchecked((byte)(value >> 48));
-            buf[offset + 0] = unchecked((byte)(value >> 56));
-        }
-
-        /*public static void XorLittleEndian32(byte[] buf, int offset, uint value)
-        {
-            buf[offset + 0] ^= (byte)value;
-            buf[offset + 1] ^= (byte)(value >> 8);
-            buf[offset + 2] ^= (byte)(value >> 16);
-            buf[offset + 3] ^= (byte)(value >> 24);
-        }*/
-
-        /*public static void XorLittleEndian32(byte[] output, int outputOffset, byte[] input, int inputOffset, uint value)
-        {
-            output[outputOffset + 0] = (byte)(input[inputOffset + 0] ^ value);
-            output[outputOffset + 1] = (byte)(input[inputOffset + 1] ^ (value >> 8));
-            output[outputOffset + 2] = (byte)(input[inputOffset + 2] ^ (value >> 16));
-            output[outputOffset + 3] = (byte)(input[inputOffset + 3] ^ (value >> 24));
-        }*/
-
-        #endregion
-
-        #region Array8
-        
-        public static void Array8LoadLittleEndian32(out Array8<uint> output, byte[] input, int inputOffset)
-        {
-            output.x0 = LoadLittleEndian32(input, inputOffset + 0);
-            output.x1 = LoadLittleEndian32(input, inputOffset + 4);
-            output.x2 = LoadLittleEndian32(input, inputOffset + 8);
-            output.x3 = LoadLittleEndian32(input, inputOffset + 12);
-            output.x4 = LoadLittleEndian32(input, inputOffset + 16);
-            output.x5 = LoadLittleEndian32(input, inputOffset + 20);
-            output.x6 = LoadLittleEndian32(input, inputOffset + 24);
-            output.x7 = LoadLittleEndian32(input, inputOffset + 28);
-        }
-
-        public static void Array8StoreLittleEndian32(byte[] output, int outputOffset, ref Array8<uint> input)
-        {
-            StoreLittleEndian32(output, outputOffset + 0, input.x0);
-            StoreLittleEndian32(output, outputOffset + 4, input.x1);
-            StoreLittleEndian32(output, outputOffset + 8, input.x2);
-            StoreLittleEndian32(output, outputOffset + 12, input.x3);
-            StoreLittleEndian32(output, outputOffset + 16, input.x4);
-            StoreLittleEndian32(output, outputOffset + 20, input.x5);
-            StoreLittleEndian32(output, outputOffset + 24, input.x6);
-            StoreLittleEndian32(output, outputOffset + 28, input.x7);
-        }
-
-        public static void Array8StoreLittleEndian32(byte[] output, int outputOffset, ref Array16<uint> input)
-        {
-            StoreLittleEndian32(output, outputOffset + 0, input.x0);
-            StoreLittleEndian32(output, outputOffset + 4, input.x1);
-            StoreLittleEndian32(output, outputOffset + 8, input.x2);
-            StoreLittleEndian32(output, outputOffset + 12, input.x3);
-            StoreLittleEndian32(output, outputOffset + 16, input.x4);
-            StoreLittleEndian32(output, outputOffset + 20, input.x5);
-            StoreLittleEndian32(output, outputOffset + 24, input.x6);
-            StoreLittleEndian32(output, outputOffset + 28, input.x7);
-        }
-
-        #endregion
-
-        #region Array16
-
-        public static void Array16LoadBigEndian64(out Array16<ulong> output, byte[] input, int inputOffset)
-        {
-            output.x0 = LoadBigEndian64(input, inputOffset + 0);
-            output.x1 = LoadBigEndian64(input, inputOffset + 8);
-            output.x2 = LoadBigEndian64(input, inputOffset + 16);
-            output.x3 = LoadBigEndian64(input, inputOffset + 24);
-            output.x4 = LoadBigEndian64(input, inputOffset + 32);
-            output.x5 = LoadBigEndian64(input, inputOffset + 40);
-            output.x6 = LoadBigEndian64(input, inputOffset + 48);
-            output.x7 = LoadBigEndian64(input, inputOffset + 56);
-            output.x8 = LoadBigEndian64(input, inputOffset + 64);
-            output.x9 = LoadBigEndian64(input, inputOffset + 72);
-            output.x10 = LoadBigEndian64(input, inputOffset + 80);
-            output.x11 = LoadBigEndian64(input, inputOffset + 88);
-            output.x12 = LoadBigEndian64(input, inputOffset + 96);
-            output.x13 = LoadBigEndian64(input, inputOffset + 104);
-            output.x14 = LoadBigEndian64(input, inputOffset + 112);
-            output.x15 = LoadBigEndian64(input, inputOffset + 120);
-        }
-
-        // TODO: Only used in tests. Remove?
-        public static void Array16LoadLittleEndian32(out Array16<uint> output, byte[] input, int inputOffset)
-        {
-            output.x0 = LoadLittleEndian32(input, inputOffset + 0);
-            output.x1 = LoadLittleEndian32(input, inputOffset + 4);
-            output.x2 = LoadLittleEndian32(input, inputOffset + 8);
-            output.x3 = LoadLittleEndian32(input, inputOffset + 12);
-            output.x4 = LoadLittleEndian32(input, inputOffset + 16);
-            output.x5 = LoadLittleEndian32(input, inputOffset + 20);
-            output.x6 = LoadLittleEndian32(input, inputOffset + 24);
-            output.x7 = LoadLittleEndian32(input, inputOffset + 28);
-            output.x8 = LoadLittleEndian32(input, inputOffset + 32);
-            output.x9 = LoadLittleEndian32(input, inputOffset + 36);
-            output.x10 = LoadLittleEndian32(input, inputOffset + 40);
-            output.x11 = LoadLittleEndian32(input, inputOffset + 44);
-            output.x12 = LoadLittleEndian32(input, inputOffset + 48);
-            output.x13 = LoadLittleEndian32(input, inputOffset + 52);
-            output.x14 = LoadLittleEndian32(input, inputOffset + 56);
-            output.x15 = LoadLittleEndian32(input, inputOffset + 60);
-        }
-
-        public static void Array16StoreLittleEndian32(byte[] output, int outputOffset, ref Array16<uint> input)
-        {
-            StoreLittleEndian32(output, outputOffset + 0, input.x0);
-            StoreLittleEndian32(output, outputOffset + 4, input.x1);
-            StoreLittleEndian32(output, outputOffset + 8, input.x2);
-            StoreLittleEndian32(output, outputOffset + 12, input.x3);
-            StoreLittleEndian32(output, outputOffset + 16, input.x4);
-            StoreLittleEndian32(output, outputOffset + 20, input.x5);
-            StoreLittleEndian32(output, outputOffset + 24, input.x6);
-            StoreLittleEndian32(output, outputOffset + 28, input.x7);
-            StoreLittleEndian32(output, outputOffset + 32, input.x8);
-            StoreLittleEndian32(output, outputOffset + 36, input.x9);
-            StoreLittleEndian32(output, outputOffset + 40, input.x10);
-            StoreLittleEndian32(output, outputOffset + 44, input.x11);
-            StoreLittleEndian32(output, outputOffset + 48, input.x12);
-            StoreLittleEndian32(output, outputOffset + 52, input.x13);
-            StoreLittleEndian32(output, outputOffset + 56, input.x14);
-            StoreLittleEndian32(output, outputOffset + 60, input.x15);
-        }
-
-        public static void Array16Copy(out Array16<uint> output, Array16<uint> input)
-        {
-            output.x0 = input.x0;
-            output.x1 = input.x1;
-            output.x2 = input.x2;
-            output.x3 = input.x3;
-            output.x4 = input.x4;
-            output.x5 = input.x5;
-            output.x6 = input.x6;
-            output.x7 = input.x7;
-            output.x8 = input.x8;
-            output.x9 = input.x9;
-            output.x10 = input.x10;
-            output.x11 = input.x11;
-            output.x12 = input.x12;
-            output.x13 = input.x13;
-            output.x14 = input.x14;
-            output.x15 = input.x15;
-        }
-
-        public static T[] Array16ToArray<T>(Array16<T> input)
-        {
-            var output = new T[16];
-            output[0] = input.x0;
-            output[1] = input.x1;
-            output[2] = input.x2;
-            output[3] = input.x3;
-            output[4] = input.x4;
-            output[5] = input.x5;
-            output[6] = input.x6;
-            output[7] = input.x7;
-            output[8] = input.x8;
-            output[9] = input.x9;
-            output[10] = input.x10;
-            output[11] = input.x11;
-            output[12] = input.x12;
-            output[13] = input.x13;
-            output[14] = input.x14;
-            output[15] = input.x15;
-            return output;
-        }
-
-        #endregion
+        return
+            (uint)(buf[offset + 0])
+            | (((uint)(buf[offset + 1])) << 8)
+            | (((uint)(buf[offset + 2])) << 16)
+            | (((uint)(buf[offset + 3])) << 24);
     }
+
+    /// <summary>
+    /// Stores the value into the buffer.
+    /// The value will be split into 4 bytes and put into four sequential places in the output buffer, starting at the specified offset.
+    /// </summary>
+    /// <param name="buf">The output buffer.</param>
+    /// <param name="offset">The output offset.</param>
+    /// <param name="value">The input value.</param>
+    public static void StoreLittleEndian32(byte[] buf, int offset, uint value)
+    {
+        buf[offset + 0] = unchecked((byte)value);
+        buf[offset + 1] = unchecked((byte)(value >> 8));
+        buf[offset + 2] = unchecked((byte)(value >> 16));
+        buf[offset + 3] = unchecked((byte)(value >> 24));
+    }
+
+    /// <summary>
+    /// Stores the value into the buffer.
+    /// The value will be split into 8 bytes and put into eight sequential places in the output buffer, starting at the specified offset.
+    /// </summary>
+    /// <param name="buf">The output buffer.</param>
+    /// <param name="offset">The output offset.</param>
+    /// <param name="value">The input value.</param>
+    public static void StoreLittleEndian64(byte[] buf, int offset, ulong value)
+    {
+        StoreLittleEndian32(buf, offset, (uint)value);
+        StoreLittleEndian32(buf, offset + 4, (uint)(value >> 32));
+    }
+
+    public static ulong LoadBigEndian64(byte[] buf, int offset)
+    {
+        return
+            (ulong)(buf[offset + 7])
+            | (((ulong)(buf[offset + 6])) << 8)
+            | (((ulong)(buf[offset + 5])) << 16)
+            | (((ulong)(buf[offset + 4])) << 24)
+            | (((ulong)(buf[offset + 3])) << 32)
+            | (((ulong)(buf[offset + 2])) << 40)
+            | (((ulong)(buf[offset + 1])) << 48)
+            | (((ulong)(buf[offset + 0])) << 56);
+    }
+
+    public static void StoreBigEndian64(byte[] buf, int offset, ulong value)
+    {
+        buf[offset + 7] = unchecked((byte)value);
+        buf[offset + 6] = unchecked((byte)(value >> 8));
+        buf[offset + 5] = unchecked((byte)(value >> 16));
+        buf[offset + 4] = unchecked((byte)(value >> 24));
+        buf[offset + 3] = unchecked((byte)(value >> 32));
+        buf[offset + 2] = unchecked((byte)(value >> 40));
+        buf[offset + 1] = unchecked((byte)(value >> 48));
+        buf[offset + 0] = unchecked((byte)(value >> 56));
+    }
+
+    /*public static void XorLittleEndian32(byte[] buf, int offset, uint value)
+    {
+        buf[offset + 0] ^= (byte)value;
+        buf[offset + 1] ^= (byte)(value >> 8);
+        buf[offset + 2] ^= (byte)(value >> 16);
+        buf[offset + 3] ^= (byte)(value >> 24);
+    }*/
+
+    /*public static void XorLittleEndian32(byte[] output, int outputOffset, byte[] input, int inputOffset, uint value)
+    {
+        output[outputOffset + 0] = (byte)(input[inputOffset + 0] ^ value);
+        output[outputOffset + 1] = (byte)(input[inputOffset + 1] ^ (value >> 8));
+        output[outputOffset + 2] = (byte)(input[inputOffset + 2] ^ (value >> 16));
+        output[outputOffset + 3] = (byte)(input[inputOffset + 3] ^ (value >> 24));
+    }*/
+
+    #endregion
+
+    #region Array8
+    
+    public static void Array8LoadLittleEndian32(out Array8<uint> output, byte[] input, int inputOffset)
+    {
+        output.x0 = LoadLittleEndian32(input, inputOffset + 0);
+        output.x1 = LoadLittleEndian32(input, inputOffset + 4);
+        output.x2 = LoadLittleEndian32(input, inputOffset + 8);
+        output.x3 = LoadLittleEndian32(input, inputOffset + 12);
+        output.x4 = LoadLittleEndian32(input, inputOffset + 16);
+        output.x5 = LoadLittleEndian32(input, inputOffset + 20);
+        output.x6 = LoadLittleEndian32(input, inputOffset + 24);
+        output.x7 = LoadLittleEndian32(input, inputOffset + 28);
+    }
+
+    public static void Array8StoreLittleEndian32(byte[] output, int outputOffset, ref Array8<uint> input)
+    {
+        StoreLittleEndian32(output, outputOffset + 0, input.x0);
+        StoreLittleEndian32(output, outputOffset + 4, input.x1);
+        StoreLittleEndian32(output, outputOffset + 8, input.x2);
+        StoreLittleEndian32(output, outputOffset + 12, input.x3);
+        StoreLittleEndian32(output, outputOffset + 16, input.x4);
+        StoreLittleEndian32(output, outputOffset + 20, input.x5);
+        StoreLittleEndian32(output, outputOffset + 24, input.x6);
+        StoreLittleEndian32(output, outputOffset + 28, input.x7);
+    }
+
+    public static void Array8StoreLittleEndian32(byte[] output, int outputOffset, ref Array16<uint> input)
+    {
+        StoreLittleEndian32(output, outputOffset + 0, input.x0);
+        StoreLittleEndian32(output, outputOffset + 4, input.x1);
+        StoreLittleEndian32(output, outputOffset + 8, input.x2);
+        StoreLittleEndian32(output, outputOffset + 12, input.x3);
+        StoreLittleEndian32(output, outputOffset + 16, input.x4);
+        StoreLittleEndian32(output, outputOffset + 20, input.x5);
+        StoreLittleEndian32(output, outputOffset + 24, input.x6);
+        StoreLittleEndian32(output, outputOffset + 28, input.x7);
+    }
+
+    #endregion
+
+    #region Array16
+
+    public static void Array16LoadBigEndian64(out Array16<ulong> output, byte[] input, int inputOffset)
+    {
+        output.x0 = LoadBigEndian64(input, inputOffset + 0);
+        output.x1 = LoadBigEndian64(input, inputOffset + 8);
+        output.x2 = LoadBigEndian64(input, inputOffset + 16);
+        output.x3 = LoadBigEndian64(input, inputOffset + 24);
+        output.x4 = LoadBigEndian64(input, inputOffset + 32);
+        output.x5 = LoadBigEndian64(input, inputOffset + 40);
+        output.x6 = LoadBigEndian64(input, inputOffset + 48);
+        output.x7 = LoadBigEndian64(input, inputOffset + 56);
+        output.x8 = LoadBigEndian64(input, inputOffset + 64);
+        output.x9 = LoadBigEndian64(input, inputOffset + 72);
+        output.x10 = LoadBigEndian64(input, inputOffset + 80);
+        output.x11 = LoadBigEndian64(input, inputOffset + 88);
+        output.x12 = LoadBigEndian64(input, inputOffset + 96);
+        output.x13 = LoadBigEndian64(input, inputOffset + 104);
+        output.x14 = LoadBigEndian64(input, inputOffset + 112);
+        output.x15 = LoadBigEndian64(input, inputOffset + 120);
+    }
+
+    // TODO: Only used in tests. Remove?
+    public static void Array16LoadLittleEndian32(out Array16<uint> output, byte[] input, int inputOffset)
+    {
+        output.x0 = LoadLittleEndian32(input, inputOffset + 0);
+        output.x1 = LoadLittleEndian32(input, inputOffset + 4);
+        output.x2 = LoadLittleEndian32(input, inputOffset + 8);
+        output.x3 = LoadLittleEndian32(input, inputOffset + 12);
+        output.x4 = LoadLittleEndian32(input, inputOffset + 16);
+        output.x5 = LoadLittleEndian32(input, inputOffset + 20);
+        output.x6 = LoadLittleEndian32(input, inputOffset + 24);
+        output.x7 = LoadLittleEndian32(input, inputOffset + 28);
+        output.x8 = LoadLittleEndian32(input, inputOffset + 32);
+        output.x9 = LoadLittleEndian32(input, inputOffset + 36);
+        output.x10 = LoadLittleEndian32(input, inputOffset + 40);
+        output.x11 = LoadLittleEndian32(input, inputOffset + 44);
+        output.x12 = LoadLittleEndian32(input, inputOffset + 48);
+        output.x13 = LoadLittleEndian32(input, inputOffset + 52);
+        output.x14 = LoadLittleEndian32(input, inputOffset + 56);
+        output.x15 = LoadLittleEndian32(input, inputOffset + 60);
+    }
+
+    public static void Array16StoreLittleEndian32(byte[] output, int outputOffset, ref Array16<uint> input)
+    {
+        StoreLittleEndian32(output, outputOffset + 0, input.x0);
+        StoreLittleEndian32(output, outputOffset + 4, input.x1);
+        StoreLittleEndian32(output, outputOffset + 8, input.x2);
+        StoreLittleEndian32(output, outputOffset + 12, input.x3);
+        StoreLittleEndian32(output, outputOffset + 16, input.x4);
+        StoreLittleEndian32(output, outputOffset + 20, input.x5);
+        StoreLittleEndian32(output, outputOffset + 24, input.x6);
+        StoreLittleEndian32(output, outputOffset + 28, input.x7);
+        StoreLittleEndian32(output, outputOffset + 32, input.x8);
+        StoreLittleEndian32(output, outputOffset + 36, input.x9);
+        StoreLittleEndian32(output, outputOffset + 40, input.x10);
+        StoreLittleEndian32(output, outputOffset + 44, input.x11);
+        StoreLittleEndian32(output, outputOffset + 48, input.x12);
+        StoreLittleEndian32(output, outputOffset + 52, input.x13);
+        StoreLittleEndian32(output, outputOffset + 56, input.x14);
+        StoreLittleEndian32(output, outputOffset + 60, input.x15);
+    }
+
+    public static void Array16Copy(out Array16<uint> output, Array16<uint> input)
+    {
+        output.x0 = input.x0;
+        output.x1 = input.x1;
+        output.x2 = input.x2;
+        output.x3 = input.x3;
+        output.x4 = input.x4;
+        output.x5 = input.x5;
+        output.x6 = input.x6;
+        output.x7 = input.x7;
+        output.x8 = input.x8;
+        output.x9 = input.x9;
+        output.x10 = input.x10;
+        output.x11 = input.x11;
+        output.x12 = input.x12;
+        output.x13 = input.x13;
+        output.x14 = input.x14;
+        output.x15 = input.x15;
+    }
+
+    public static T[] Array16ToArray<T>(Array16<T> input)
+    {
+        var output = new T[16];
+        output[0] = input.x0;
+        output[1] = input.x1;
+        output[2] = input.x2;
+        output[3] = input.x3;
+        output[4] = input.x4;
+        output[5] = input.x5;
+        output[6] = input.x6;
+        output[7] = input.x7;
+        output[8] = input.x8;
+        output[9] = input.x9;
+        output[10] = input.x10;
+        output[11] = input.x11;
+        output[12] = input.x12;
+        output[13] = input.x13;
+        output[14] = input.x14;
+        output[15] = input.x15;
+        return output;
+    }
+
+    #endregion
 }

--- a/src/Paseto/Cryptography/Internal/ByteIntegerConverter.cs
+++ b/src/Paseto/Cryptography/Internal/ByteIntegerConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace Paseto.Cryptography.Internal
+﻿using System;
+
+namespace Paseto.Cryptography.Internal
 {
     // Loops? Arrays? Never heard of that stuff
     // Library avoids unnecessary heap allocations and unsafe code
@@ -13,7 +15,7 @@
         /// <param name="buf">The input buffer.</param>
         /// <param name="offset">The input offset.</param>
         /// <returns>System.UInt32.</returns>
-        public static uint LoadLittleEndian32(byte[] buf, int offset)
+        public static uint LoadLittleEndian32(Span<byte> buf, int offset)
         {
             return
                 (uint)(buf[offset + 0])

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/fe_tobytes.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/fe_tobytes.cs
@@ -1,4 +1,6 @@
-﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+﻿using System;
+
+namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 internal static partial class FieldOperations
 {
@@ -26,7 +28,7 @@ internal static partial class FieldOperations
       Have q+2^(-255)x = 2^(-255)(h + 19 2^(-25) h9 + 2^(-1))
       so floor(2^(-255)(h + 19 2^(-25) h9 + 2^(-1))) = q.
     */
-    internal static void fe_tobytes(byte[] s, int offset, ref FieldElement h)
+    internal static void fe_tobytes(Span<byte> s, int offset, ref FieldElement h)
     {
         fe_reduce(out FieldElement hr, ref h);
 

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/fe_tobytes.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/fe_tobytes.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
-namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+using System;
 
 internal static partial class FieldOperations
 {

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_double_scalarmult.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_double_scalarmult.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
-namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+using System;
 
 internal static partial class GroupOperations
 {

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_double_scalarmult.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_double_scalarmult.cs
@@ -1,8 +1,10 @@
-﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+﻿using System;
+
+namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 internal static partial class GroupOperations
 {
-    private static void slide(sbyte[] r, byte[] a)
+    private static void slide(Span<sbyte> r, Span<byte> a)
     {
         int i;
         int b;
@@ -51,12 +53,12 @@ and b = b[0]+256*b[1]+...+256^31 b[31].
 B is the Ed25519 base point (x,4/5) with x positive.
 */
 
-    internal static void ge_double_scalarmult_vartime(out GroupElementP2 r, byte[] a, ref GroupElementP3 A, byte[] b)
+    internal static void ge_double_scalarmult_vartime(out GroupElementP2 r, byte[] a, ref GroupElementP3 A, Span<byte> b)
     {
         GroupElementPreComp[] Bi = LookupTables.Base2;
         // TODO: Perhaps remove these allocations?
-        var aslide = new sbyte[256];
-        var bslide = new sbyte[256];
+        Span<sbyte> aslide = stackalloc sbyte[256];
+        Span<sbyte> bslide = stackalloc sbyte[256];
         var Ai = new GroupElementCached[8]; /* A,3A,5A,7A,9A,11A,13A,15A */
         int i;
 

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_double_scalarmult.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_double_scalarmult.cs
@@ -56,7 +56,6 @@ B is the Ed25519 base point (x,4/5) with x positive.
     internal static void ge_double_scalarmult_vartime(out GroupElementP2 r, byte[] a, ref GroupElementP3 A, Span<byte> b)
     {
         GroupElementPreComp[] Bi = LookupTables.Base2;
-        // TODO: Perhaps remove these allocations?
         Span<sbyte> aslide = stackalloc sbyte[256];
         Span<sbyte> bslide = stackalloc sbyte[256];
         var Ai = new GroupElementCached[8]; /* A,3A,5A,7A,9A,11A,13A,15A */

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_scalarmult_base.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_scalarmult_base.cs
@@ -1,4 +1,6 @@
-﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+﻿using System;
+
+namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 internal static partial class GroupOperations
 {
@@ -62,7 +64,7 @@ internal static partial class GroupOperations
     internal static void ge_scalarmult_base(out GroupElementP3 h, byte[] a, int offset)
     {
         // TODO: Perhaps remove this allocation
-        var e = new sbyte[64];
+        Span<sbyte> e = stackalloc sbyte[64];
         sbyte carry;
         GroupElementP1P1 r;
         GroupElementP2 s;

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_scalarmult_base.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_scalarmult_base.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
-namespace Paseto.Cryptography.Internal.Ed25519Ref10;
-
+using System;
 internal static partial class GroupOperations
 {
     private static byte equal(byte b, byte c)
@@ -63,7 +62,6 @@ internal static partial class GroupOperations
 
     internal static void ge_scalarmult_base(out GroupElementP3 h, byte[] a, int offset)
     {
-        // TODO: Perhaps remove this allocation
         Span<sbyte> e = stackalloc sbyte[64];
         sbyte carry;
         GroupElementP1P1 r;

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_tobytes.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_tobytes.cs
@@ -1,8 +1,10 @@
-﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+﻿using System;
+
+namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 internal static partial class GroupOperations
 {
-    internal static void ge_tobytes(byte[] s, int offset, ref GroupElementP2 h)
+    internal static void ge_tobytes(Span<byte> s, int offset, ref GroupElementP2 h)
     {
         FieldOperations.fe_invert(out FieldElement recip, ref h.Z);
         FieldOperations.fe_mul(out FieldElement x, ref h.X, ref recip);

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/open.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/open.cs
@@ -67,12 +67,12 @@ internal static partial class Ed25519Operations
         ScalarOperations.sc_reduce(h);
 
         Span<byte> sm32 = stackalloc byte[32];
-        CryptoBytesExtensions.SpanCopy(sig, sigoffset + 32, sm32, 0, 32);
+        SpanExtensions.Copy(sig, sigoffset + 32, sm32, 0, 32);
 
         GroupOperations.ge_double_scalarmult_vartime(out R, h, ref A, sm32);
         GroupOperations.ge_tobytes(checkr, 0, ref R);
         var sliceLength = 32;
-        var result = CryptoBytes.ConstantTimeEquals(checkr.Slice(0, sliceLength),sig.Slice(sigoffset, sliceLength));
+        var result = CryptoBytes.ConstantTimeEquals(checkr.Slice(0, sliceLength), sig.Slice(sigoffset, sliceLength));
         CryptoBytes.Wipe(h);
         CryptoBytesExtensions.Wipe(checkr);
         return result;

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/open.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/open.cs
@@ -71,7 +71,7 @@ internal static partial class Ed25519Operations
 
         GroupOperations.ge_double_scalarmult_vartime(out R, h, ref A, sm32);
         GroupOperations.ge_tobytes(checkr, 0, ref R);
-        var sliceLength = 32;
+        const int sliceLength = 32;
         var result = CryptoBytes.ConstantTimeEquals(checkr.Slice(0, sliceLength), sig.Slice(sigoffset, sliceLength));
         CryptoBytes.Wipe(h);
         CryptoBytesExtensions.Wipe(checkr);

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_clamp.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_clamp.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
-namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+using System;
 
 internal static partial class ScalarOperations
 {
@@ -10,6 +10,7 @@ internal static partial class ScalarOperations
         s[offset + 31] &= 127;
         s[offset + 31] |= 64;
     }
+
     internal static void sc_clamp(byte[] s, int offset)
     {
         s[offset + 0] &= 248;

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_clamp.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_clamp.cs
@@ -1,7 +1,15 @@
-﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+﻿using System;
+
+namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 internal static partial class ScalarOperations
 {
+    internal static void sc_clamp(Span<byte> s, int offset)
+    {
+        s[offset + 0] &= 248;
+        s[offset + 31] &= 127;
+        s[offset + 31] |= 64;
+    }
     internal static void sc_clamp(byte[] s, int offset)
     {
         s[offset + 0] &= 248;

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
-namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+using System;
 
 internal static partial class ScalarOperations
 {

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
@@ -34,7 +34,7 @@ internal static partial class ScalarOperations
       where l = 2^252 + 27742317777372353535851937790883648493.
     */
 
-    internal static void sc_muladd(byte[] s, byte[] a, byte[] b, byte[] c)
+    internal static void sc_muladd(Span<byte> s, byte[] a, byte[] b, byte[] c)
     {
         long a0 = 2097151 & load_3(a, 0);
         long a1 = 2097151 & (load_4(a, 2) >> 5);

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
@@ -1,8 +1,10 @@
-﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+﻿using System;
+
+namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 internal static partial class ScalarOperations
 {
-    private static long load_3(byte[] input, int offset)
+    private static long load_3(Span<byte> input, int offset)
     {
         long result;
         result = (long)input[offset + 0];
@@ -11,7 +13,7 @@ internal static partial class ScalarOperations
         return result;
     }
 
-    private static long load_4(byte[] input, int offset)
+    private static long load_4(Span<byte> input, int offset)
     {
         long result;
         result = (long)input[offset + 0];

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_reduce.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_reduce.cs
@@ -1,4 +1,6 @@
-﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+﻿using System;
+
+namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 internal static partial class ScalarOperations
 {
@@ -11,7 +13,7 @@ internal static partial class ScalarOperations
       where l = 2^252 + 27742317777372353535851937790883648493.
       Overwrites s in place.
     */
-    internal static void sc_reduce(byte[] s)
+    internal static void sc_reduce(Span<byte> s)
     {
         long s0 = 2097151 & load_3(s, 0);
         long s1 = 2097151 & (load_4(s, 2) >> 5);

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_reduce.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_reduce.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
-namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+using System;
 
 internal static partial class ScalarOperations
 {

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/scalarmult.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/scalarmult.cs
@@ -1,8 +1,6 @@
 ﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 using System;
-using System.Runtime.CompilerServices;
-using NaCl.Core.Internal;
 using Paseto.Extensions;
 
 internal static class MontgomeryOperations
@@ -186,7 +184,6 @@ internal static class MontgomeryOperations
             FieldOperations.fe_mul(out z2, ref tmp1, ref tmp0);
 
             /* qhasm: return */
-
         }
         FieldOperations.fe_cswap(ref x2, ref x3, swap);
         FieldOperations.fe_cswap(ref z2, ref z3, swap);

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/scalarmult.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/scalarmult.cs
@@ -1,6 +1,9 @@
 ﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
+using System;
+using System.Runtime.CompilerServices;
 using NaCl.Core.Internal;
+using Paseto.Extensions;
 
 internal static class MontgomeryOperations
 {
@@ -13,8 +16,8 @@ internal static class MontgomeryOperations
 
     internal static void scalarmult(out FieldElement q, byte[] n, int noffset, ref FieldElement p)
     {
-        var e = new byte[32]; // TODO: remove allocation
-        uint i;
+        Span<byte> e = stackalloc byte[32];
+        int i;
         FieldElement x1;
         FieldElement x2;
         FieldElement z2;
@@ -191,6 +194,6 @@ internal static class MontgomeryOperations
         FieldOperations.fe_invert(out z2, ref z2);
         FieldOperations.fe_mul(out x2, ref x2, ref z2);
         q = x2;
-        CryptoBytes.Wipe(e);
+        CryptoBytesExtensions.Wipe(e);
     }
 }

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sign.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sign.cs
@@ -1,7 +1,6 @@
 ﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 using System;
-using NaCl.Core.Internal;
 using Paseto.Extensions;
 
 internal static partial class Ed25519Operations

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sign.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sign.cs
@@ -2,6 +2,7 @@
 
 using System;
 using NaCl.Core.Internal;
+using Paseto.Extensions;
 
 internal static partial class Ed25519Operations
 {
@@ -67,11 +68,11 @@ internal static partial class Ed25519Operations
             hram = hasher.Finish();
 
             ScalarOperations.sc_reduce(hram);
-            var s = new byte[32]; // TODO: remove allocation
-            Array.Copy(sig, sigoffset + 32, s, 0, 32);
+            Span<byte> s = stackalloc byte[32];
+            CryptoBytesExtensions.SpanCopy(sig, sigoffset + 32, s, 0, 32);
             ScalarOperations.sc_muladd(s, hram, az, r);
-            Array.Copy(s, 0, sig, sigoffset + 32, 32);
-            CryptoBytes.Wipe(s);
+            CryptoBytesExtensions.SpanCopy(s, 0, sig, sigoffset + 32, 32);
+            CryptoBytesExtensions.Wipe(s);
         }
     }
 }

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sign.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sign.cs
@@ -69,9 +69,9 @@ internal static partial class Ed25519Operations
 
             ScalarOperations.sc_reduce(hram);
             Span<byte> s = stackalloc byte[32];
-            CryptoBytesExtensions.SpanCopy(sig, sigoffset + 32, s, 0, 32);
+            SpanExtensions.Copy(sig, sigoffset + 32, s, 0, 32);
             ScalarOperations.sc_muladd(s, hram, az, r);
-            CryptoBytesExtensions.SpanCopy(s, 0, sig, sigoffset + 32, 32);
+            SpanExtensions.Copy(s, 0, sig, sigoffset + 32, 32);
             CryptoBytesExtensions.Wipe(s);
         }
     }

--- a/src/Paseto/Cryptography/Internal/Poly1305Donna.cs
+++ b/src/Paseto/Cryptography/Internal/Poly1305Donna.cs
@@ -1,6 +1,7 @@
 ﻿namespace Paseto.Cryptography.Internal
 {
     using System;
+    using Paseto.Extensions;
 
     /// <summary>
     /// Poly1305 message authentication code, designed by D. J. Bernstein.
@@ -103,7 +104,7 @@
             if (mLength == 0)
                 goto poly1305_donna_finish;
 
-            var mp = new byte[BlockSize]; // TODO: Remove allocation
+            Span<byte> mp = stackalloc byte[BlockSize];
 
             for (j = 0; j < mLength; j++)
                 mp[j] = m[mStart + j];
@@ -116,7 +117,7 @@
             t1 = ByteIntegerConverter.LoadLittleEndian32(mp, 4);
             t2 = ByteIntegerConverter.LoadLittleEndian32(mp, 8);
             t3 = ByteIntegerConverter.LoadLittleEndian32(mp, 12);
-            NaCl.Core.Internal.CryptoBytes.Wipe(mp);
+            CryptoBytesExtensions.Wipe(mp);
 
             h0 += t0 & 0x3ffffff;
             h1 += (uint)(((((ulong)t1 << 32) | t0) >> 26) & 0x3ffffff);

--- a/src/Paseto/Cryptography/Sha512.cs
+++ b/src/Paseto/Cryptography/Sha512.cs
@@ -57,7 +57,7 @@ public class Sha512
         if (bytesInBuffer != 0)
         {
             var toCopy = Math.Min(BlockSize - bytesInBuffer, count);
-            CryptoBytesExtensions.SpanCopy(data, offset, _buffer, bytesInBuffer, toCopy);
+            SpanExtensions.Copy(data, offset, _buffer, bytesInBuffer, toCopy);
             offset += toCopy;
             count -= toCopy;
             bytesInBuffer += toCopy;
@@ -81,7 +81,14 @@ public class Sha512
 
         // Copy remainder into buffer
         if (count > 0)
-            CryptoBytesExtensions.SpanCopy(data, offset, _buffer, bytesInBuffer, count);
+
+            /* Unmerged change from project 'Paseto (net6.0)'
+            Before:
+                        CryptoBytesExtensions.SpanCopy(data, offset, _buffer, bytesInBuffer, count);
+            After:
+                        Extensions.SpanExtensions.SpanCopy(data, offset, _buffer, bytesInBuffer, count);
+            */
+            SpanExtensions.Copy(data, offset, _buffer, bytesInBuffer, count);
     }
 
     public void Finish(ArraySegment<byte> output)

--- a/src/Paseto/Cryptography/Sha512.cs
+++ b/src/Paseto/Cryptography/Sha512.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Paseto.Cryptography.Internal;
+using Paseto.Extensions;
 
 public class Sha512
 {
@@ -31,7 +32,7 @@ public class Sha512
         Update(data.Array, data.Offset, data.Count);
     }
 
-    public void Update(byte[] data, int offset, int count)
+    public void Update(Span<byte> data, int offset, int count)
     {
         if (data == null)
             throw new ArgumentNullException(nameof(data));
@@ -56,7 +57,7 @@ public class Sha512
         if (bytesInBuffer != 0)
         {
             var toCopy = Math.Min(BlockSize - bytesInBuffer, count);
-            Buffer.BlockCopy(data, offset, _buffer, bytesInBuffer, toCopy);
+            CryptoBytesExtensions.SpanCopy(data, offset, _buffer, bytesInBuffer, toCopy);
             offset += toCopy;
             count -= toCopy;
             bytesInBuffer += toCopy;
@@ -72,7 +73,7 @@ public class Sha512
         // Hash complete blocks without copying
         while (count >= BlockSize)
         {
-            ByteIntegerConverter.Array16LoadBigEndian64(out block, data, offset);
+            ByteIntegerConverterExtensions.Array16LoadBigEndian64(out block, data, offset);
             Sha512Internal.Core(out _state, ref _state, ref block);
             offset += BlockSize;
             count -= BlockSize;
@@ -80,7 +81,7 @@ public class Sha512
 
         // Copy remainder into buffer
         if (count > 0)
-            Buffer.BlockCopy(data, offset, _buffer, bytesInBuffer, count);
+            CryptoBytesExtensions.SpanCopy(data, offset, _buffer, bytesInBuffer, count);
     }
 
     public void Finish(ArraySegment<byte> output)

--- a/src/Paseto/Extensions/ByteIntegerConverterExtensions.cs
+++ b/src/Paseto/Extensions/ByteIntegerConverterExtensions.cs
@@ -1,0 +1,36 @@
+﻿namespace Paseto.Extensions;
+
+using System;
+using Paseto.Cryptography.Internal;
+
+public static class ByteIntegerConverterExtensions
+{
+    public static void Array16LoadBigEndian64(out Array16<ulong> output, Span<byte> input, int inputOffset)
+    {
+        output.x0 = LoadBigEndian64(input, inputOffset + 0);
+        output.x1 = LoadBigEndian64(input, inputOffset + 8);
+        output.x2 = LoadBigEndian64(input, inputOffset + 16);
+        output.x3 = LoadBigEndian64(input, inputOffset + 24);
+        output.x4 = LoadBigEndian64(input, inputOffset + 32);
+        output.x5 = LoadBigEndian64(input, inputOffset + 40);
+        output.x6 = LoadBigEndian64(input, inputOffset + 48);
+        output.x7 = LoadBigEndian64(input, inputOffset + 56);
+        output.x8 = LoadBigEndian64(input, inputOffset + 64);
+        output.x9 = LoadBigEndian64(input, inputOffset + 72);
+        output.x10 = LoadBigEndian64(input, inputOffset + 80);
+        output.x11 = LoadBigEndian64(input, inputOffset + 88);
+        output.x12 = LoadBigEndian64(input, inputOffset + 96);
+        output.x13 = LoadBigEndian64(input, inputOffset + 104);
+        output.x14 = LoadBigEndian64(input, inputOffset + 112);
+        output.x15 = LoadBigEndian64(input, inputOffset + 120);
+    }
+
+    public static ulong LoadBigEndian64(Span<byte> buf, int offset) => (ulong)(buf[offset + 7])
+            | (((ulong)(buf[offset + 6])) << 8)
+            | (((ulong)(buf[offset + 5])) << 16)
+            | (((ulong)(buf[offset + 4])) << 24)
+            | (((ulong)(buf[offset + 3])) << 32)
+            | (((ulong)(buf[offset + 2])) << 40)
+            | (((ulong)(buf[offset + 1])) << 48)
+            | (((ulong)(buf[offset + 0])) << 56);
+}

--- a/src/Paseto/Extensions/CryptoBytesExtensions.cs
+++ b/src/Paseto/Extensions/CryptoBytesExtensions.cs
@@ -7,5 +7,8 @@ public static class CryptoBytesExtensions
 {
     [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void InternalWipe(Span<byte> data, int offset, int count) => data.Slice(offset, count).Clear();
+
     public static void Wipe(Span<byte> data) => InternalWipe(data, 0, data.Length);
+
+    public static void SpanCopy(Span<byte> sourceSpan, int sourceIndex, Span<byte> destinationSpan, int destinationIndex, int length) => sourceSpan.Slice(sourceIndex, length).CopyTo(destinationSpan.Slice(destinationIndex, length));
 }

--- a/src/Paseto/Extensions/CryptoBytesExtensions.cs
+++ b/src/Paseto/Extensions/CryptoBytesExtensions.cs
@@ -9,6 +9,4 @@ public static class CryptoBytesExtensions
     internal static void InternalWipe(Span<byte> data, int offset, int count) => data.Slice(offset, count).Clear();
 
     public static void Wipe(Span<byte> data) => InternalWipe(data, 0, data.Length);
-
-    public static void SpanCopy(Span<byte> sourceSpan, int sourceIndex, Span<byte> destinationSpan, int destinationIndex, int length) => sourceSpan.Slice(sourceIndex, length).CopyTo(destinationSpan.Slice(destinationIndex, length));
 }

--- a/src/Paseto/Extensions/CryptoBytesExtensions.cs
+++ b/src/Paseto/Extensions/CryptoBytesExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace Paseto.Extensions;
+
+using System;
+using System.Runtime.CompilerServices;
+
+public static class CryptoBytesExtensions
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static void InternalWipe(Span<byte> data, int offset, int count) => data.Slice(offset, count).Clear();
+    public static void Wipe(Span<byte> data) => InternalWipe(data, 0, data.Length);
+}

--- a/src/Paseto/Extensions/CryptoBytesExtensions.cs
+++ b/src/Paseto/Extensions/CryptoBytesExtensions.cs
@@ -8,5 +8,8 @@ public static class CryptoBytesExtensions
     [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void InternalWipe(Span<byte> data, int offset, int count) => data.Slice(offset, count).Clear();
 
-    public static void Wipe(Span<byte> data) => InternalWipe(data, 0, data.Length);
+    public static void Wipe(Span<byte> data)
+    {
+        InternalWipe(data, 0, data.Length);
+    }
 }

--- a/src/Paseto/Extensions/SpanExtensions.cs
+++ b/src/Paseto/Extensions/SpanExtensions.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿namespace Paseto.Extensions;
 
-namespace Paseto.Extensions;
+using System;
 
 internal static class SpanExtensions
 {
-
     public static void Copy(Span<byte> sourceSpan, int sourceIndex, Span<byte> destinationSpan, int destinationIndex, int length) => sourceSpan.Slice(sourceIndex, length).CopyTo(destinationSpan.Slice(destinationIndex, length));
 }

--- a/src/Paseto/Extensions/SpanExtensions.cs
+++ b/src/Paseto/Extensions/SpanExtensions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Paseto.Extensions;
+
+internal static class SpanExtensions
+{
+
+    public static void Copy(Span<byte> sourceSpan, int sourceIndex, Span<byte> destinationSpan, int destinationIndex, int length) => sourceSpan.Slice(sourceIndex, length).CopyTo(destinationSpan.Slice(destinationIndex, length));
+}

--- a/tests/Paseto.Tests/Extensions/CryptoBytesExtensionsTests.cs
+++ b/tests/Paseto.Tests/Extensions/CryptoBytesExtensionsTests.cs
@@ -1,0 +1,39 @@
+﻿namespace Paseto.Tests.Extensions;
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Paseto.Extensions;
+using Paseto.Tests.Crypto;
+using Xunit;
+
+public class CryptoBytesExtensionsTests
+{
+    private readonly byte[] _bytes = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray();
+
+    [Fact]
+    public void Wipe()
+    {
+        var bytes = (byte[])_bytes.Clone();
+        CryptoBytesExtensions.Wipe(bytes);
+        bytes.All(b => b == 0).Should().BeTrue();
+    }
+
+    [Fact]
+    public void WipeSegment()
+    {
+        var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var wipedBytes = new byte[] { 1, 2, 0, 0, 0, 0, 0, 8, 9, 10 };
+        CryptoBytesExtensions.Wipe(new ArraySegment<byte>(bytes, 2, 5));
+        TestHelpers.AssertEqualBytes(wipedBytes, bytes);
+    }
+
+    [Fact]
+    public void WipeSlice()
+    {
+        Span<byte> bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        Span<byte> wipedBytes = new byte[] { 1, 2, 0, 0, 0, 0, 0, 8, 9, 10 };
+        CryptoBytesExtensions.Wipe(bytes.Slice(2, 5));
+        TestHelpers.AssertEqualBytes(wipedBytes.ToArray(), bytes.ToArray());
+    }
+}

--- a/tests/Paseto.Tests/Extensions/SpanExtensionsTests.cs
+++ b/tests/Paseto.Tests/Extensions/SpanExtensionsTests.cs
@@ -1,0 +1,52 @@
+﻿namespace Paseto.Tests.Extensions;
+
+using System;
+using FluentAssertions;
+using Paseto.Extensions;
+using Xunit;
+
+public class SpanExtensionsTests
+{
+    [Theory]
+    [InlineData(0, 0, 10)]
+    [InlineData(0, 1, 5)]
+    [InlineData(1, 0, 5)]
+    [InlineData(5, 5, 5)]
+    public void SpanCopyShouldCorrectlyCopySlice(int sourceIndex, int destinationIndex, int length)
+    {
+        // Arrange
+        var source = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+        var expected = new byte[] { 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 };
+        var destination = new byte[] { 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 };
+        Array.Copy(source, sourceIndex, expected, destinationIndex, length);
+
+        // Act
+        SpanExtensions.Copy(source, sourceIndex, destination, destinationIndex, length);
+
+        // Assert
+        destination.Should().BeEquivalentTo(expected);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 11)]
+    [InlineData(0, 0, -1)]
+    [InlineData(-1, -1, 10)]
+    [InlineData(-1, 0, 10)]
+    [InlineData(0, -1, 10)]
+    [InlineData(1, 1, 10)]
+    [InlineData(1, 0, 10)]
+    [InlineData(0, 1, 10)]
+    [InlineData(11, 11, 10)]
+    [InlineData(11, 0, 10)]
+    [InlineData(0, 11, 10)]
+    public void SpanCopyShouldThrowErrorWhenGivenOutOfBoundsArguments(int sourceIndex, int destinationIndex, int length)
+    {
+        // Arrange
+        var source = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var destination = new byte[] { 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 };
+
+        // Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => SpanExtensions.Copy(source, sourceIndex, destination, destinationIndex, length));
+    }
+}


### PR DESCRIPTION
Hey was checking out Paseto when I found your library. 

I've gone through the allocation TODOs and replaced `byte[]` allocations with `Span<byte>`, I've attempted to avoid changing logic or code flow, relying on adding or modifying existing methods. 

When Spans weren't compatible with NaCl.Core I added two extension methods `ByteIntegerConverterExtensions` and `CryptoBytesExtensions` with adapted code.