### PR TITLE
Remove redundant code

### DIFF
--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_clamp.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_clamp.cs
@@ -10,11 +10,4 @@ internal static partial class ScalarOperations
         s[offset + 31] &= 127;
         s[offset + 31] |= 64;
     }
-
-    internal static void sc_clamp(byte[] s, int offset)
-    {
-        s[offset + 0] &= 248;
-        s[offset + 31] &= 127;
-        s[offset + 31] |= 64;
-    }
 }

--- a/src/Paseto/Cryptography/Sha512.cs
+++ b/src/Paseto/Cryptography/Sha512.cs
@@ -81,13 +81,6 @@ public class Sha512
 
         // Copy remainder into buffer
         if (count > 0)
-
-            /* Unmerged change from project 'Paseto (net6.0)'
-            Before:
-                        CryptoBytesExtensions.SpanCopy(data, offset, _buffer, bytesInBuffer, count);
-            After:
-                        Extensions.SpanExtensions.SpanCopy(data, offset, _buffer, bytesInBuffer, count);
-            */
             SpanExtensions.Copy(data, offset, _buffer, bytesInBuffer, count);
     }
 

--- a/src/Paseto/Cryptography/Sha512.cs
+++ b/src/Paseto/Cryptography/Sha512.cs
@@ -24,17 +24,9 @@ public class Sha512
         _totalBytes = 0;
     }
 
-    public void Update(ArraySegment<byte> data)
-    {
-        if (data.Array == null)
-            throw new ArgumentNullException("data.Array");
-
-        Update(data.Array, data.Offset, data.Count);
-    }
-
     public void Update(Span<byte> data, int offset, int count)
     {
-        if (data == null)
+        if (data == default)
             throw new ArgumentNullException(nameof(data));
 
         if (offset < 0)

--- a/tests/Paseto.Tests/Crypto/Sha512Tests.cs
+++ b/tests/Paseto.Tests/Crypto/Sha512Tests.cs
@@ -140,9 +140,9 @@ public class Sha512Tests
     }
 
     [Fact]
-    public void Sha512UpdateSegmentsNull()
+    public void Sha512UpdateNull()
     {
         var sha512 = new Sha512();
-        Assert.Throws<ArgumentNullException>(() => sha512.Update(default));
+        Assert.Throws<ArgumentNullException>(() => sha512.Update(default,0,0));
     }
 }


### PR DESCRIPTION
Minor code cleanup
- Removed redundant `sc_clamp` overload
- Removed redundant `Update` overload
- Spans aren't nullable so changed the null check to a default check.
- Updated test