### PR TITLE
Added benchmarks for V1-V4 for encrypt, decrypt, sign and verify

### DIFF
--- a/Paseto.sln
+++ b/Paseto.sln
@@ -15,13 +15,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
-		README.md = README.md
+		appveyor.yml = appveyor.yml
 		build.cake = build.cake
-		global.json = global.json
 		CodeCoverage.runsettings = CodeCoverage.runsettings
 		dotnet-tools.json = dotnet-tools.json
-		appveyor.yml = appveyor.yml
+		global.json = global.json
+		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{F0BF64B6-8BAE-4480-8F75-D1BFC8D6A834}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paseto.Benchmark", "benchmarks\Paseto.Benchmark\Paseto.Benchmark.csproj", "{0C98CD46-6B22-4003-8D2E-9D89902B960D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,6 +41,10 @@ Global
 		{2FAB1426-5BDB-4835-9323-676F3E286D57}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FAB1426-5BDB-4835-9323-676F3E286D57}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FAB1426-5BDB-4835-9323-676F3E286D57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C98CD46-6B22-4003-8D2E-9D89902B960D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C98CD46-6B22-4003-8D2E-9D89902B960D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C98CD46-6B22-4003-8D2E-9D89902B960D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C98CD46-6B22-4003-8D2E-9D89902B960D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -44,6 +52,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{AF52242B-5578-4D7D-AB4E-22ED6BF5F3F8} = {C0AB8266-F1F2-43C3-9D0B-0FE7EBAEAC70}
 		{2FAB1426-5BDB-4835-9323-676F3E286D57} = {1313DA53-FE67-4E72-8CE2-BEEE48276907}
+		{0C98CD46-6B22-4003-8D2E-9D89902B960D} = {F0BF64B6-8BAE-4480-8F75-D1BFC8D6A834}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {24CC8E07-0D90-436B-ABC1-E088813D210A}

--- a/benchmarks/Paseto.Benchmark/Paseto.Benchmark.csproj
+++ b/benchmarks/Paseto.Benchmark/Paseto.Benchmark.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="xunit.assert" Version="2.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Paseto\Paseto.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Paseto.Benchmark/Program.cs
+++ b/benchmarks/Paseto.Benchmark/Program.cs
@@ -28,8 +28,8 @@ public class Benchmarks
         _symmetricKey = new PasetoBuilder().Use(Version, Purpose.Local).GenerateSymmetricKey();
         _asymmetricKeyPair = new PasetoBuilder().Use(Version, Purpose.Public).GenerateAsymmetricKeyPair(_seed);
 
-        _localToken = LocalEncode();
-        _publicToken = PublicEncode();
+        _localToken = Encrypt();
+        _publicToken = Sign();
     }
 
     [ParamsAllValues]
@@ -46,12 +46,12 @@ public class Benchmarks
                                                                       .AddClaim("Test2", "Value2");
 
     [Benchmark]
-    public string LocalEncode() => CreateBuilder().Use(Version, Purpose.Local)
+    public string Encrypt() => CreateBuilder().Use(Version, Purpose.Local)
                               .WithKey(_symmetricKey)
                               .Encode();
 
     [Benchmark]
-    public PasetoTokenValidationResult LocalDecode()
+    public PasetoTokenValidationResult Decrypt()
     {
         var result = CreateBuilder().Use(Version, Purpose.Local)
                                     .WithKey(_symmetricKey)
@@ -62,12 +62,12 @@ public class Benchmarks
     }
 
     [Benchmark]
-    public string PublicEncode() => CreateBuilder().Use(Version, Purpose.Public)
+    public string Sign() => CreateBuilder().Use(Version, Purpose.Public)
                                                    .WithKey(_asymmetricKeyPair.SecretKey)
                                                    .Encode();
 
     [Benchmark]
-    public PasetoTokenValidationResult PublicDecode()
+    public PasetoTokenValidationResult Verify()
     {
         var result = CreateBuilder().Use(Version, Purpose.Public)
                                     .WithKey(_asymmetricKeyPair.PublicKey)

--- a/benchmarks/Paseto.Benchmark/Program.cs
+++ b/benchmarks/Paseto.Benchmark/Program.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using Paseto;
+using Paseto.Builder;
+using Paseto.Cryptography.Key;
+using Xunit;
+
+BenchmarkRunner.Run<Benchmarks>();
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net50)]
+[SimpleJob(RuntimeMoniker.Net60)]
+[JsonExporterAttribute.Full]
+[JsonExporterAttribute.FullCompressed]
+public class Benchmarks
+{
+    private readonly byte[] _seed = new byte[32];
+    private PasetoSymmetricKey _symmetricKey = null!;
+    private PasetoAsymmetricKeyPair _asymmetricKeyPair = null!;
+    private string _localToken = null!;
+    private string _publicToken = null!;
+
+    [GlobalSetup]
+    public void SetUp()
+    {
+        _symmetricKey = new PasetoBuilder().Use(Version, Purpose.Local).GenerateSymmetricKey();
+        _asymmetricKeyPair = new PasetoBuilder().Use(Version, Purpose.Public).GenerateAsymmetricKeyPair(_seed);
+
+        _localToken = LocalEncode();
+        _publicToken = PublicEncode();
+    }
+
+    [ParamsAllValues]
+    public ProtocolVersion Version { get; set; }
+
+    // TODO Experiment with a large claim/many claims
+    public static PasetoBuilder CreateBuilder() => new PasetoBuilder().Issuer("localhost:5000")
+                                                                      .Subject("PASETO-DEMO")
+                                                                      .Audience("paseto.io")
+                                                                      .NotBefore(DateTime.UtcNow)
+                                                                      .IssuedAt(DateTime.UtcNow)
+                                                                      .Expiration(DateTime.UtcNow.AddHours(1))
+                                                                      .AddClaim("Test", "Value")
+                                                                      .AddClaim("Test2", "Value2");
+
+    [Benchmark]
+    public string LocalEncode() => CreateBuilder().Use(Version, Purpose.Local)
+                              .WithKey(_symmetricKey)
+                              .Encode();
+
+    [Benchmark]
+    public PasetoTokenValidationResult LocalDecode()
+    {
+        var result = CreateBuilder().Use(Version, Purpose.Local)
+                                    .WithKey(_symmetricKey)
+                                    .Decode(_localToken);
+
+        Assert.True(result.IsValid);
+        return result;
+    }
+
+    [Benchmark]
+    public string PublicEncode() => CreateBuilder().Use(Version, Purpose.Public)
+                                                   .WithKey(_asymmetricKeyPair.SecretKey)
+                                                   .Encode();
+
+    [Benchmark]
+    public PasetoTokenValidationResult PublicDecode()
+    {
+        var result = CreateBuilder().Use(Version, Purpose.Public)
+                                    .WithKey(_asymmetricKeyPair.PublicKey)
+                                    .Decode(_publicToken);
+
+        Assert.True(result.IsValid);
+        return result;
+    }
+}


### PR DESCRIPTION
Created some Benchmarks that cover both versions of .net, all protocol versions, both purposes and each form of encode/decode. Not sure how to structure/name it so created a benchmarks folder and added .Benchmark suffix.

The benchmarks work and appear to give realistic values with the exception of Verify/Sign in V1 and V3. All other operations typically take 40-120 us and allocate 20 KB of memory, whereas V1 and V3 Verify/Sign take up to 8,400 us and allocate 7000 KB of memory. Is this due to bouncy castle implementation or should this be expected with RSA?



