### PR TITLE
Remove allocations

### DIFF
--- a/src/Paseto/Cryptography/Ed25519.cs
+++ b/src/Paseto/Cryptography/Ed25519.cs
@@ -43,30 +43,30 @@ public static class Ed25519
         return Ed25519Operations.crypto_sign_verify(signature, 0, message, 0, message.Length, publicKey, 0);
     }
 
-    public static void Sign(ArraySegment<byte> signature, ArraySegment<byte> message, ArraySegment<byte> expandedPrivateKey)
+    public static void Sign(Span<byte> signature, ReadOnlySpan<byte> message, ReadOnlySpan<byte> expandedPrivateKey)
     {
-        if (signature.Array == null)
+        if (signature == default)
             throw new ArgumentNullException("signature.Array");
 
-        if (signature.Count != SignatureSizeInBytes)
-            throw new ArgumentException("signature.Count");
+        if (signature.Length != SignatureSizeInBytes)
+            throw new ArgumentException("signature.Length");
 
-        if (expandedPrivateKey.Array == null)
+        if (expandedPrivateKey == default)
             throw new ArgumentNullException("expandedPrivateKey.Array");
 
-        if (expandedPrivateKey.Count != ExpandedPrivateKeySizeInBytes)
-            throw new ArgumentException("expandedPrivateKey.Count");
+        if (expandedPrivateKey.Length != ExpandedPrivateKeySizeInBytes)
+            throw new ArgumentException("expandedPrivateKey.Length");
 
-        if (message.Array == null)
+        if (message == default)
             throw new ArgumentNullException("message.Array");
 
-        Ed25519Operations.crypto_sign2(signature.Array, signature.Offset, message.Array, message.Offset, message.Count, expandedPrivateKey.Array, expandedPrivateKey.Offset);
+        Ed25519Operations.crypto_sign2(signature, message, expandedPrivateKey);
     }
 
-    public static byte[] Sign(byte[] message, byte[] expandedPrivateKey)
+    public static byte[] Sign(Span<byte> message, ReadOnlySpan<byte> expandedPrivateKey)
     {
         var signature = new byte[SignatureSizeInBytes];
-        Sign(new ArraySegment<byte>(signature), new ArraySegment<byte>(message), new ArraySegment<byte>(expandedPrivateKey));
+        Sign(signature, message, expandedPrivateKey);
         return signature;
     }
 

--- a/src/Paseto/Cryptography/Ed25519.cs
+++ b/src/Paseto/Cryptography/Ed25519.cs
@@ -12,26 +12,15 @@ public static class Ed25519
     public static readonly int PrivateKeySeedSizeInBytes = 32;
     public static readonly int SharedKeySizeInBytes = 32;
 
-    public static bool Verify(ArraySegment<byte> signature, ArraySegment<byte> message, ArraySegment<byte> publicKey)
+    public static bool Verify(ReadOnlySpan<byte> signature, ReadOnlySpan<byte> message, ReadOnlySpan<byte> publicKey)
     {
-        if (signature.Count != SignatureSizeInBytes)
-            throw new ArgumentException(string.Format("Signature size must be {0}", SignatureSizeInBytes), "signature.Count");
-
-        if (publicKey.Count != PublicKeySizeInBytes)
-            throw new ArgumentException(string.Format("Public key size must be {0}", PublicKeySizeInBytes), "publicKey.Count");
-
-        return Ed25519Operations.crypto_sign_verify(signature.Array, signature.Offset, message.Array, message.Offset, message.Count, publicKey.Array, publicKey.Offset);
-    }
-
-    public static bool Verify(byte[] signature, byte[] message, byte[] publicKey)
-    {
-        if (signature == null)
+        if (signature == default)
             throw new ArgumentNullException(nameof(signature));
 
-        if (message == null)
+        if (message == default)
             throw new ArgumentNullException(nameof(message));
 
-        if (publicKey == null)
+        if (publicKey == default)
             throw new ArgumentNullException(nameof(publicKey));
 
         if (signature.Length != SignatureSizeInBytes)

--- a/src/Paseto/Cryptography/Internal/Blake2bNormal.cs
+++ b/src/Paseto/Cryptography/Internal/Blake2bNormal.cs
@@ -1,4 +1,6 @@
-﻿namespace Paseto.Cryptography;
+﻿using System;
+
+namespace Paseto.Cryptography;
 
 internal class Blake2bNormal : Blake2bBase
 {
@@ -8,8 +10,8 @@ internal class Blake2bNormal : Blake2bBase
 
     public override void Compress(bool isFinal)
     {
-        var v = new ulong[16];
-        var m = new ulong[16];
+        Span<ulong> v = stackalloc ulong[16];
+        Span<ulong> m = stackalloc ulong[16];
 
         for (var i = 0; i < 8; ++i)
             v[i] = Hash[i];

--- a/src/Paseto/Cryptography/Internal/Blake2bSlow.cs
+++ b/src/Paseto/Cryptography/Internal/Blake2bSlow.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 
 namespace Paseto.Cryptography;
 
@@ -13,8 +14,8 @@ internal class Blake2bSlow : Blake2bBase
         Debug.Assert(DataBuffer.Length == 128);
         Debug.Assert(Hash.Length == 8);
 
-        var v = new ulong[16];
-        var m = new ulong[16];
+        Span<ulong> v = stackalloc ulong[16];
+        Span<ulong> m = stackalloc ulong[16];
 
         for (var i = 0; i < 8; ++i)
             v[i] = Hash[i];
@@ -52,7 +53,7 @@ internal class Blake2bSlow : Blake2bBase
 
     private static ulong RotateSlow(ulong x, int y) => (((x) >> (y)) ^ ((x) << (64 - (y))));
 
-    private static void SlowG(ulong[] v, int a, int b, int c, int d, ulong x, ulong y)
+    private static void SlowG(Span<ulong> v, int a, int b, int c, int d, ulong x, ulong y)
     {
         v[a] = v[a] + v[b] + x;
         v[d] = RotateSlow(v[d] ^ v[a], 32);
@@ -64,7 +65,7 @@ internal class Blake2bSlow : Blake2bBase
         v[b] = RotateSlow(v[b] ^ v[c], 63);
     }
 
-    private static void DoRoundSlow(ulong[] v, ulong[] m, int i)
+    private static void DoRoundSlow(Span<ulong> v, ReadOnlySpan<ulong> m, int i)
     {
         SlowG(v, 0, 4, 8, 12, m[Blake2Constants.Sigma[i][0]], m[Blake2Constants.Sigma[i][1]]);
         SlowG(v, 1, 5, 9, 13, m[Blake2Constants.Sigma[i][2]], m[Blake2Constants.Sigma[i][3]]);

--- a/src/Paseto/Cryptography/Internal/ByteIntegerConverter.cs
+++ b/src/Paseto/Cryptography/Internal/ByteIntegerConverter.cs
@@ -65,16 +65,16 @@ internal static class ByteIntegerConverter
             | (((ulong)(buf[offset + 0])) << 56);
     }
 
-    public static void StoreBigEndian64(Span<byte> buf, int offset, ulong value)
+    public static void StoreBigEndian64(Span<byte> buf, ulong value)
     {
-        buf[offset + 7] = unchecked((byte)value);
-        buf[offset + 6] = unchecked((byte)(value >> 8));
-        buf[offset + 5] = unchecked((byte)(value >> 16));
-        buf[offset + 4] = unchecked((byte)(value >> 24));
-        buf[offset + 3] = unchecked((byte)(value >> 32));
-        buf[offset + 2] = unchecked((byte)(value >> 40));
-        buf[offset + 1] = unchecked((byte)(value >> 48));
-        buf[offset + 0] = unchecked((byte)(value >> 56));
+        buf[7] = unchecked((byte)value);
+        buf[6] = unchecked((byte)(value >> 8));
+        buf[5] = unchecked((byte)(value >> 16));
+        buf[4] = unchecked((byte)(value >> 24));
+        buf[3] = unchecked((byte)(value >> 32));
+        buf[2] = unchecked((byte)(value >> 40));
+        buf[1] = unchecked((byte)(value >> 48));
+        buf[0] = unchecked((byte)(value >> 56));
     }
 
     /*public static void XorLittleEndian32(byte[] buf, int offset, uint value)

--- a/src/Paseto/Cryptography/Internal/ByteIntegerConverter.cs
+++ b/src/Paseto/Cryptography/Internal/ByteIntegerConverter.cs
@@ -65,7 +65,7 @@ internal static class ByteIntegerConverter
             | (((ulong)(buf[offset + 0])) << 56);
     }
 
-    public static void StoreBigEndian64(byte[] buf, int offset, ulong value)
+    public static void StoreBigEndian64(Span<byte> buf, int offset, ulong value)
     {
         buf[offset + 7] = unchecked((byte)value);
         buf[offset + 6] = unchecked((byte)(value >> 8));

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/fe_frombytes.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/fe_frombytes.cs
@@ -1,8 +1,10 @@
 ﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
+using System;
+
 internal static partial class FieldOperations
 {
-    private static long load_3(byte[] data, int offset)
+    private static long load_3(ReadOnlySpan<byte> data, int offset)
     {
         uint result;
         result = (uint)data[offset + 0];
@@ -11,7 +13,7 @@ internal static partial class FieldOperations
         return (long)(ulong)result;
     }
 
-    private static long load_4(byte[] data, int offset)
+    private static long load_4(ReadOnlySpan<byte> data, int offset)
     {
         uint result;
         result = (uint)data[offset + 0];
@@ -22,7 +24,7 @@ internal static partial class FieldOperations
     }
 
     //	Ignores top bit of h.
-    internal static void fe_frombytes(out FieldElement h, byte[] data, int offset)
+    internal static void fe_frombytes(out FieldElement h, ReadOnlySpan<byte> data, int offset)
     {
         long h0 = load_4(data, offset);
         long h1 = load_3(data, offset + 4) << 6;

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_frombytes.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_frombytes.cs
@@ -1,8 +1,10 @@
 ﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
+using System;
+
 internal static partial class GroupOperations
 {
-    internal static int ge_frombytes_negate_vartime(out GroupElementP3 h, byte[] data, int offset)
+    internal static int ge_frombytes_negate_vartime(out GroupElementP3 h, ReadOnlySpan<byte> data, int offset)
     {
         FieldOperations.fe_frombytes(out h.Y, data, offset);
         FieldOperations.fe_1(out h.Z);

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_p3_tobytes.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_p3_tobytes.cs
@@ -1,8 +1,10 @@
-﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
+﻿using System;
+
+namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 internal static partial class GroupOperations
 {
-    internal static void ge_p3_tobytes(byte[] s, int offset, ref GroupElementP3 h)
+    internal static void ge_p3_tobytes(Span<byte> s, int offset, ref GroupElementP3 h)
     {
         FieldOperations.fe_invert(out FieldElement recip, ref h.Z);
         FieldOperations.fe_mul(out FieldElement x, ref h.X, ref recip);

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_scalarmult_base.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/ge_scalarmult_base.cs
@@ -60,7 +60,7 @@ internal static partial class GroupOperations
       a[31] <= 127
     */
 
-    internal static void ge_scalarmult_base(out GroupElementP3 h, byte[] a, int offset)
+    internal static void ge_scalarmult_base(out GroupElementP3 h, ReadOnlySpan<byte> a, int offset)
     {
         Span<sbyte> e = stackalloc sbyte[64];
         sbyte carry;

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/keypair.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/keypair.cs
@@ -1,23 +1,28 @@
 ﻿namespace Paseto.Cryptography.Internal.Ed25519Ref10;
 
 using System;
-using NaCl.Core.Internal;
+using Paseto.Extensions;
 
 internal static partial class Ed25519Operations
 {
-    internal static void crypto_sign_keypair(byte[] pk, int pkoffset, byte[] sk, int skoffset, byte[] seed, int seedoffset)
+    internal static void crypto_sign_keypair(Span<byte> pk, int pkoffset, Span<byte> sk, int skoffset, ReadOnlySpan<byte> seed, int seedoffset)
     {
         GroupElementP3 A;
         int i;
+        Span<byte> h = stackalloc byte[64];
 
-        Array.Copy(seed, seedoffset, sk, skoffset, 32);
-        var h = Sha512.Hash(sk, skoffset, 32); // TODO: Remove alloc
+        SpanExtensions.Copy(seed, seedoffset, sk, skoffset, 32);
+
+        var hasher = new Sha512();
+        hasher.Update(sk, skoffset, 32);
+        hasher.Finish(h);
+
         ScalarOperations.sc_clamp(h, 0);
 
         GroupOperations.ge_scalarmult_base(out A, h, 0);
         GroupOperations.ge_p3_tobytes(pk, pkoffset, ref A);
 
-        for (i = 0; i < 32; ++i) sk[skoffset + 32 + i] = pk[pkoffset + i];
-        CryptoBytes.Wipe(h);
+        SpanExtensions.Copy(pk, pkoffset, sk, skoffset+32, 32);
+        CryptoBytesExtensions.Wipe(h);
     }
 }

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/open.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/open.cs
@@ -47,7 +47,7 @@ internal static partial class Ed25519Operations
         return 0;
     }*/
 
-    internal static bool crypto_sign_verify(Span<byte> sig, int sigoffset, byte[] m, int moffset, int mlen, byte[] pk, int pkoffset)
+    internal static bool crypto_sign_verify(ReadOnlySpan<byte> sig, int sigoffset, ReadOnlySpan<byte> m, int moffset, int mlen, ReadOnlySpan<byte> pk, int pkoffset)
     {
         byte[] h;
         Span<byte> checkr = stackalloc byte[32];

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
@@ -4,7 +4,7 @@ using System;
 
 internal static partial class ScalarOperations
 {
-    private static long load_3(Span<byte> input, int offset)
+    private static long load_3(ReadOnlySpan<byte> input, int offset)
     {
         long result;
         result = (long)input[offset + 0];
@@ -13,7 +13,7 @@ internal static partial class ScalarOperations
         return result;
     }
 
-    private static long load_4(Span<byte> input, int offset)
+    private static long load_4(ReadOnlySpan<byte> input, int offset)
     {
         long result;
         result = (long)input[offset + 0];

--- a/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
+++ b/src/Paseto/Cryptography/Internal/Ed25519Ref10/sc_mul_add.cs
@@ -34,7 +34,7 @@ internal static partial class ScalarOperations
       where l = 2^252 + 27742317777372353535851937790883648493.
     */
 
-    internal static void sc_muladd(Span<byte> s, byte[] a, byte[] b, byte[] c)
+    internal static void sc_muladd(Span<byte> s, ReadOnlySpan<byte> a, ReadOnlySpan<byte> b, ReadOnlySpan<byte> c)
     {
         long a0 = 2097151 & load_3(a, 0);
         long a1 = 2097151 & (load_4(a, 2) >> 5);

--- a/src/Paseto/Cryptography/Sha512.cs
+++ b/src/Paseto/Cryptography/Sha512.cs
@@ -24,7 +24,7 @@ public class Sha512
         _totalBytes = 0;
     }
 
-    public void Update(Span<byte> data, int offset, int count)
+    public void Update(ReadOnlySpan<byte> data, int offset, int count)
     {
         if (data == default)
             throw new ArgumentNullException(nameof(data));
@@ -37,6 +37,17 @@ public class Sha512
 
         if (data.Length - offset < count)
             throw new ArgumentException("Requires offset + count <= data.Length");
+
+        Update(data.Slice(offset, count));
+    }
+
+    public void Update(ReadOnlySpan<byte> data)
+    {
+        if (data == default)
+            throw new ArgumentNullException(nameof(data));
+
+        var count = data.Length;
+        var offset = 0;
 
         Array16<ulong> block;
         var bytesInBuffer = (int)_totalBytes & (BlockSize - 1);

--- a/src/Paseto/Extensions/ByteIntegerConverterExtensions.cs
+++ b/src/Paseto/Extensions/ByteIntegerConverterExtensions.cs
@@ -5,7 +5,7 @@ using Paseto.Cryptography.Internal;
 
 public static class ByteIntegerConverterExtensions
 {
-    public static void Array16LoadBigEndian64(out Array16<ulong> output, Span<byte> input, int inputOffset)
+    public static void Array16LoadBigEndian64(out Array16<ulong> output, ReadOnlySpan<byte> input, int inputOffset)
     {
         output.x0 = LoadBigEndian64(input, inputOffset + 0);
         output.x1 = LoadBigEndian64(input, inputOffset + 8);
@@ -25,7 +25,7 @@ public static class ByteIntegerConverterExtensions
         output.x15 = LoadBigEndian64(input, inputOffset + 120);
     }
 
-    public static ulong LoadBigEndian64(Span<byte> buf, int offset) => (ulong)(buf[offset + 7])
+    public static ulong LoadBigEndian64(ReadOnlySpan<byte> buf, int offset) => (ulong)(buf[offset + 7])
             | (((ulong)(buf[offset + 6])) << 8)
             | (((ulong)(buf[offset + 5])) << 16)
             | (((ulong)(buf[offset + 4])) << 24)

--- a/src/Paseto/Extensions/SpanExtensions.cs
+++ b/src/Paseto/Extensions/SpanExtensions.cs
@@ -4,5 +4,5 @@ using System;
 
 internal static class SpanExtensions
 {
-    public static void Copy(Span<byte> sourceSpan, int sourceIndex, Span<byte> destinationSpan, int destinationIndex, int length) => sourceSpan.Slice(sourceIndex, length).CopyTo(destinationSpan.Slice(destinationIndex, length));
+    public static void Copy(ReadOnlySpan<byte> sourceSpan, int sourceIndex, Span<byte> destinationSpan, int destinationIndex, int length) => sourceSpan.Slice(sourceIndex, length).CopyTo(destinationSpan.Slice(destinationIndex, length));
 }

--- a/src/Paseto/Protocol/Version2.cs
+++ b/src/Paseto/Protocol/Version2.cs
@@ -317,7 +317,7 @@ public class Version2 : PasetoProtocolVersion, IPasetoProtocolVersion
         var header = $"{Version}.{Purpose.Public.ToDescription()}.";
         var pack = PreAuthEncode(new[] { header, payload, footer });
 
-        var signature = Ed25519.Sign(pack, pasetoKey.Key.ToArray());
+        var signature = Ed25519.Sign(pack, pasetoKey.Key.Span);
 
         if (!string.IsNullOrEmpty(footer))
             footer = $".{ToBase64Url(GetBytes(footer))}";
@@ -399,7 +399,7 @@ public class Version2 : PasetoProtocolVersion, IPasetoProtocolVersion
 
         var pack = PreAuthEncode(new[] { GetBytes(header), payload, f });
 
-        var valid = Ed25519.Verify(signature, pack, pasetoKey.Key.ToArray());
+        var valid = Ed25519.Verify(signature, pack, pasetoKey.Key.Span);
 
         return valid ? PasetoVerifyResult.Success(GetString(payload)) : PasetoVerifyResult.Failed;
     }

--- a/src/Paseto/Protocol/Version4.cs
+++ b/src/Paseto/Protocol/Version4.cs
@@ -342,7 +342,7 @@ public class Version4 : PasetoProtocolVersion, IPasetoProtocolVersion
         var header = $"{Version}.{Purpose.Public.ToDescription()}.";
         var pack = PreAuthEncode(new[] { header, payload, footer, assertion });
 
-        var signature = Ed25519.Sign(pack, pasetoKey.Key.ToArray());
+        var signature = Ed25519.Sign(pack, pasetoKey.Key.Span);
 
         if (!string.IsNullOrEmpty(footer))
             footer = $".{ToBase64Url(GetBytes(footer))}";
@@ -423,7 +423,7 @@ public class Version4 : PasetoProtocolVersion, IPasetoProtocolVersion
 
         var pack = PreAuthEncode(new[] { GetBytes(header), payload, f, GetBytes(assertion) });
 
-        var valid = Ed25519.Verify(signature, pack, pasetoKey.Key.ToArray());
+        var valid = Ed25519.Verify(signature, pack, pasetoKey.Key.Span);
 
         return valid ? PasetoVerifyResult.Success(GetString(payload)) : PasetoVerifyResult.Failed;
     }

--- a/src/Paseto/Utils/Base64UrlEncoder.cs
+++ b/src/Paseto/Utils/Base64UrlEncoder.cs
@@ -10,12 +10,12 @@ using System;
 /// </summary>
 public class Base64UrlEncoder : IBase64UrlEncoder
 {
-    private static readonly char OnePadChar = '=';
-    private static readonly string TwoPadChar = "==";
-    private static readonly char Char62 = '+';
-    private static readonly char Char63 = '/';
-    private static readonly char UrlChar62 = '-';
-    private static readonly char UrlChar63 = '_';
+    private const char OnePadChar = '=';
+    private const string TwoPadChar = "==";
+    private const char Char62 = '+';
+    private const char Char63 = '/';
+    private const char UrlChar62 = '-';
+    private const char UrlChar63 = '_';
 
     private static readonly char[] OnePads = { OnePadChar };
 

--- a/src/Paseto/Utils/EncodingHelper.cs
+++ b/src/Paseto/Utils/EncodingHelper.cs
@@ -84,7 +84,7 @@ internal static class EncodingHelper
         var up = ~~(n / 0xffffffff);
         var dn = (n % 0xffffffff) - up;
 
-        var buf = new byte[8].AsSpan();
+        Span<byte> buf = stackalloc byte[8];
         BinaryPrimitives.WriteUInt32LittleEndian(buf[4..], (uint)up);
         BinaryPrimitives.WriteUInt32LittleEndian(buf, (uint)dn);
 

--- a/src/Paseto/Utils/EncodingHelper.cs
+++ b/src/Paseto/Utils/EncodingHelper.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Paseto.Extensions;
-using System.Buffers.Text;
 
 /// <summary>
 /// The Encoding Helper.


### PR DESCRIPTION
- Refactored `PreAuthEncode` and `LE64`
- Removed allocations in `crypto_sign_keypair`, `sign`, `Blake2bNormal` and `Blake2bSlow`
- Changed various methods to use `Span` and `ReadOnlySpan`
- Refactored `Sha512`, `Ed25519`, `sign` and `verify` to accept spans
- Saved about 1-2kb of allocations with mild performance boosts