### PR TITLE
test: future proof via MemberData

### DIFF
--- a/tests/Paseto.Tests/PaserkTests.cs
+++ b/tests/Paseto.Tests/PaserkTests.cs
@@ -22,13 +22,7 @@ public class PaserkTests
 
     public PaserkTests(ITestOutputHelper output) => _output = output;
 
-    private static readonly ProtocolVersion[] ValidProtocols =
-    [
-        ProtocolVersion.V1,
-        ProtocolVersion.V2,
-        ProtocolVersion.V3,
-        ProtocolVersion.V4
-    ];
+    private static readonly ProtocolVersion[] ValidProtocols = Enum.GetValues<ProtocolVersion>();
 
     private static readonly PaserkType[] SupportedPaserkTypes =
     [

--- a/tests/Paseto.Tests/PasetoBuilderTests.cs
+++ b/tests/Paseto.Tests/PasetoBuilderTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 
 using FluentAssertions;
@@ -106,10 +107,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should throw exception on GenerateSymmetricKey when incorrect purpose is provided")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldThrowExceptionOnGenerateSymmetricKeyWhenIncorrectPurposeIsProvided(ProtocolVersion version)
     {
         var incorrectPurpose = Purpose.Public;
@@ -151,10 +149,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should throw exception on GenerateAsymmetricKeyPair when incorrect purpose is provided")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldThrowExceptionOnGenerateAsymmetricKeyPairWhenIncorrectPurposeIsProvided(ProtocolVersion version)
     {
         var incorrectPurpose = Purpose.Local;
@@ -166,18 +161,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should throw exception on GenerateAsymmetricKeyPair when invalid seed is provided")]
-    [InlineData(ProtocolVersion.V2, null)]
-    [InlineData(ProtocolVersion.V2, new byte[0])]
-    [InlineData(ProtocolVersion.V2, new byte[] { 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V2, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V3, null)]
-    [InlineData(ProtocolVersion.V3, new byte[0])]
-    [InlineData(ProtocolVersion.V3, new byte[] { 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V3, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V4, null)]
-    [InlineData(ProtocolVersion.V4, new byte[0])]
-    [InlineData(ProtocolVersion.V4, new byte[] { 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V4, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
+    [MemberData(nameof(VersionsAndInvalidSeedData))]
     public void ShouldThrowExceptionOnGenerateAsymmetricKeyPairWhenInvalidSeedIsProvided(ProtocolVersion version, byte[] seed)
     {
         Action act = () => new PasetoBuilder().Use(version, Purpose.Public)
@@ -190,10 +174,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should succeed on Local Encode with Byte Array Key and optional Footer when dependencies are provided")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldSucceedOnLocalEncodeWithByteArrayKeyAndOptionalFooterWhenDependenciesAreProvided(ProtocolVersion version)
     {
         var token = new PasetoBuilder().Use(version, Purpose.Local)
@@ -215,10 +196,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should succeed on Local Encode with Byte Array Key and optional Footer Payload when dependencies are provided")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldSucceedOnLocalEncodeWithByteArrayKeyAndOptionalFooterPayloadWhenDependenciesAreProvided(ProtocolVersion version)
     {
         var token = new PasetoBuilder().Use(version, Purpose.Local)
@@ -240,10 +218,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should succeed on Local Encode with Byte Array Key when dependencies are provided")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldSucceedOnLocalEncodeWithByteArrayKeyWhenDependenciesAreProvided(ProtocolVersion version)
     {
         var token = new PasetoBuilder().Use(version, Purpose.Local)
@@ -332,14 +307,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should throw exception on Encode when WithKey is not called")]
-    [InlineData(ProtocolVersion.V1, Purpose.Local)]
-    [InlineData(ProtocolVersion.V1, Purpose.Public)]
-    [InlineData(ProtocolVersion.V2, Purpose.Local)]
-    [InlineData(ProtocolVersion.V2, Purpose.Public)]
-    [InlineData(ProtocolVersion.V3, Purpose.Local)]
-    [InlineData(ProtocolVersion.V3, Purpose.Public)]
-    [InlineData(ProtocolVersion.V4, Purpose.Local)]
-    [InlineData(ProtocolVersion.V4, Purpose.Public)]
+    [MemberData(nameof(AllVersionsAndPurposesData), MemberType = typeof(TestHelper))]
     public void ShouldThrowExceptionOnEncodeWhenWithKeyIsNotCalled(ProtocolVersion version, Purpose purpose)
     {
         Action act = () => new PasetoBuilder().Use(version, purpose)
@@ -349,14 +317,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should throw exception on Encode when Payload is not added")]
-    [InlineData(ProtocolVersion.V1, Purpose.Local)]
-    [InlineData(ProtocolVersion.V1, Purpose.Public)]
-    [InlineData(ProtocolVersion.V2, Purpose.Local)]
-    [InlineData(ProtocolVersion.V2, Purpose.Public)]
-    [InlineData(ProtocolVersion.V3, Purpose.Local)]
-    [InlineData(ProtocolVersion.V3, Purpose.Public)]
-    [InlineData(ProtocolVersion.V4, Purpose.Local)]
-    [InlineData(ProtocolVersion.V4, Purpose.Public)]
+    [MemberData(nameof(AllVersionsAndPurposesData), MemberType = typeof(TestHelper))]
     public void ShouldThrowExceptionOnEncodeWhenPayloadIsNotAdded(ProtocolVersion version, Purpose purpose)
     {
         Action act = () => new PasetoBuilder().Use(version, purpose)
@@ -367,18 +328,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should throw exception on Local Encode when invalid key is provided")]
-    [InlineData(ProtocolVersion.V1, null)]
-    [InlineData(ProtocolVersion.V1, new byte[0])]
-    [InlineData(ProtocolVersion.V1, new byte[] { 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V2, null)]
-    [InlineData(ProtocolVersion.V2, new byte[0])]
-    [InlineData(ProtocolVersion.V2, new byte[] { 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V3, null)]
-    [InlineData(ProtocolVersion.V3, new byte[0])]
-    [InlineData(ProtocolVersion.V3, new byte[] { 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V4, null)]
-    [InlineData(ProtocolVersion.V4, new byte[0])]
-    [InlineData(ProtocolVersion.V4, new byte[] { 0x00, 0x00 })]
+    [MemberData(nameof(VersionsAndInvalidKeyData))]
     public void ShouldThrowExceptionOnLocalEncodeWhenInvalidKeyIsProvided(ProtocolVersion version, byte[] key)
     {
         Action act = () => new PasetoBuilder().Use(version, Purpose.Local)
@@ -391,18 +341,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should throw exception on Public Encode when invalid key is provided")]
-    [InlineData(ProtocolVersion.V1, null)]
-    [InlineData(ProtocolVersion.V1, new byte[0])]
-    [InlineData(ProtocolVersion.V1, new byte[] { 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V2, null)]
-    [InlineData(ProtocolVersion.V2, new byte[0])]
-    [InlineData(ProtocolVersion.V2, new byte[] { 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V3, null)]
-    [InlineData(ProtocolVersion.V3, new byte[0])]
-    [InlineData(ProtocolVersion.V3, new byte[] { 0x00, 0x00 })]
-    [InlineData(ProtocolVersion.V4, null)]
-    [InlineData(ProtocolVersion.V4, new byte[0])]
-    [InlineData(ProtocolVersion.V4, new byte[] { 0x00, 0x00 })]
+    [MemberData(nameof(VersionsAndInvalidKeyData))]
     public void ShouldThrowExceptionOnPublicEncodeWhenInvalidKeyIsProvided(ProtocolVersion version, byte[] key)
     {
         Action act = () => new PasetoBuilder().Use(version, Purpose.Public)
@@ -512,10 +451,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should succeed on Encode to PARSEK when is Local Purpose and Symmetric Key")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldSucceedOnEncodeToParsekWhenIsLocalPurposeAndSymmetricKey(ProtocolVersion version)
     {
         var parsek = new PasetoBuilder().Use(version, Purpose.Local)
@@ -527,10 +463,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should succeed on Encode to PARSEK when is Local Purpose and Shared Key")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldSucceedOnEncodeToParsekWhenIsLocalPurposeAndSharedKey(ProtocolVersion version)
     {
         var parsek = new PasetoBuilder().Use(version, Purpose.Local)
@@ -542,10 +475,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should succeed on Encode to PARSEK when is Public Purpose and Public Asymmetric Key")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldSucceedOnEncodeToParsekWhenIsPublicPurposeAndPublicAsymmetricKey(ProtocolVersion version)
     {
         var keyLength = version switch
@@ -569,10 +499,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should succeed on Encode to PARSEK when is Public Purpose and Secret Asymmetric Key")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldSucceedOnEncodeToParsekWhenIsPublicPurposeAndSecretAsymmetricKey(ProtocolVersion version)
     {
         var keyLength = version switch
@@ -596,10 +523,7 @@ public class PasetoBuilderTests
     }
 
     [Theory(DisplayName = "Should succeed on Decoding with Date Validations")]
-    [InlineData(ProtocolVersion.V1)]
-    [InlineData(ProtocolVersion.V2)]
-    [InlineData(ProtocolVersion.V3)]
-    [InlineData(ProtocolVersion.V4)]
+    [MemberData(nameof(AllVersionsData), MemberType = typeof(TestHelper))]
     public void ShouldSucceedOnDecodingWithDateValidations(ProtocolVersion version)
     {
         const Purpose purpose = Purpose.Public;
@@ -640,5 +564,42 @@ public class PasetoBuilderTests
             .Decode(encoded, validationParameters);
 
         decoded.IsValid.Should().BeTrue();
+    }
+
+    public static TheoryData<ProtocolVersion, byte[]> VersionsAndInvalidKeyData()
+    {
+        var bytes = new List<byte[]>
+        {
+            null,
+            Array.Empty<byte>(),
+            new byte[] { 0x80, 0x00 }
+        };
+
+        var ret = new TheoryData<ProtocolVersion, byte[]>();
+
+        foreach (var version in Enum.GetValues<ProtocolVersion>())
+        foreach (var key in bytes)
+            ret.Add(version, key);
+
+        return ret;
+    }
+
+    public static TheoryData<ProtocolVersion, byte[]> VersionsAndInvalidSeedData()
+    {
+        var bytes = new List<byte[]>
+        {
+            null,
+            Array.Empty<byte>(),
+            new byte[] { 0x80, 0x00 },
+            new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
+        };
+
+        var ret = new TheoryData<ProtocolVersion, byte[]>();
+
+        foreach (var version in Enum.GetValues<ProtocolVersion>().Where(x => x != ProtocolVersion.V1))
+        foreach (var key in bytes)
+            ret.Add(version, key);
+
+        return ret;
     }
 }

--- a/tests/Paseto.Tests/PasetoTestVectors.cs
+++ b/tests/Paseto.Tests/PasetoTestVectors.cs
@@ -12,9 +12,9 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Categories;
 
-using Paseto.Builder;
-using Paseto.Cryptography;
-using Paseto.Tests.Vectors;
+using Builder;
+using Cryptography;
+using Vectors;
 
 using static TestHelper;
 
@@ -28,10 +28,7 @@ public class PasetoTestVectors
     public PasetoTestVectors(ITestOutputHelper output) => _output = output;
 
     [Theory]
-    [InlineData("v1")]
-    [InlineData("v2")]
-    [InlineData("v3")]
-    [InlineData("v4")]
+    [MemberData(nameof(VersionStringNameData), MemberType = typeof(TestHelper))]
     public void VersionTestVectors(string version)
     {
         var json = GetPasetoTestVector(version);

--- a/tests/Paseto.Tests/PasetoValidationTest.cs
+++ b/tests/Paseto.Tests/PasetoValidationTest.cs
@@ -1,24 +1,16 @@
 ﻿namespace Paseto.Tests;
 
-using System;
 using System.ComponentModel;
 using System.Linq;
 using FluentAssertions;
-using Paseto.Builder;
-using Paseto.Cryptography.Key;
+using Builder;
+using Cryptography.Key;
 using Xunit;
 
 public sealed class PasetoValidationTest
 {
     [Theory(DisplayName = "Should succeed on token with valid audience")]
-    [InlineData(ProtocolVersion.V1, Purpose.Local)]
-    [InlineData(ProtocolVersion.V1, Purpose.Public)]
-    [InlineData(ProtocolVersion.V2, Purpose.Local)]
-    [InlineData(ProtocolVersion.V2, Purpose.Public)]
-    [InlineData(ProtocolVersion.V3, Purpose.Local)]
-    [InlineData(ProtocolVersion.V3, Purpose.Public)]
-    [InlineData(ProtocolVersion.V4, Purpose.Local)]
-    [InlineData(ProtocolVersion.V4, Purpose.Public)]
+    [MemberData(nameof(TestHelper.AllVersionsAndPurposesData), MemberType = typeof(TestHelper))]
     public void TokenWithValidAudienceValidationSucceeds(ProtocolVersion version, Purpose purpose)
     {
         var validationParameters = new PasetoTokenValidationParameters()
@@ -37,14 +29,7 @@ public sealed class PasetoValidationTest
     }
 
     [Theory(DisplayName = "Should fail on token with invalid audience")]
-    [InlineData(ProtocolVersion.V1, Purpose.Local)]
-    [InlineData(ProtocolVersion.V1, Purpose.Public)]
-    [InlineData(ProtocolVersion.V2, Purpose.Local)]
-    [InlineData(ProtocolVersion.V2, Purpose.Public)]
-    [InlineData(ProtocolVersion.V3, Purpose.Local)]
-    [InlineData(ProtocolVersion.V3, Purpose.Public)]
-    [InlineData(ProtocolVersion.V4, Purpose.Local)]
-    [InlineData(ProtocolVersion.V4, Purpose.Public)]
+    [MemberData(nameof(TestHelper.AllVersionsAndPurposesData), MemberType = typeof(TestHelper))]
     public void TokenWithInValidAudienceValidationFails(ProtocolVersion version, Purpose purpose)
     {
         var validationParameters = new PasetoTokenValidationParameters()
@@ -63,14 +48,7 @@ public sealed class PasetoValidationTest
     }
 
     [Theory(DisplayName = "Should succeed on token with valid issuer")]
-    [InlineData(ProtocolVersion.V1, Purpose.Local)]
-    [InlineData(ProtocolVersion.V1, Purpose.Public)]
-    [InlineData(ProtocolVersion.V2, Purpose.Local)]
-    [InlineData(ProtocolVersion.V2, Purpose.Public)]
-    [InlineData(ProtocolVersion.V3, Purpose.Local)]
-    [InlineData(ProtocolVersion.V3, Purpose.Public)]
-    [InlineData(ProtocolVersion.V4, Purpose.Local)]
-    [InlineData(ProtocolVersion.V4, Purpose.Public)]
+    [MemberData(nameof(TestHelper.AllVersionsAndPurposesData), MemberType = typeof(TestHelper))]
     public void TokenWithValidIssuerValidationSucceeds(ProtocolVersion version, Purpose purpose)
     {
         var validationParameters = new PasetoTokenValidationParameters()
@@ -89,14 +67,7 @@ public sealed class PasetoValidationTest
     }
 
     [Theory(DisplayName = "Should fail on token with invalid issuer")]
-    [InlineData(ProtocolVersion.V1, Purpose.Local)]
-    [InlineData(ProtocolVersion.V1, Purpose.Public)]
-    [InlineData(ProtocolVersion.V2, Purpose.Local)]
-    [InlineData(ProtocolVersion.V2, Purpose.Public)]
-    [InlineData(ProtocolVersion.V3, Purpose.Local)]
-    [InlineData(ProtocolVersion.V3, Purpose.Public)]
-    [InlineData(ProtocolVersion.V4, Purpose.Local)]
-    [InlineData(ProtocolVersion.V4, Purpose.Public)]
+    [MemberData(nameof(TestHelper.AllVersionsAndPurposesData), MemberType = typeof(TestHelper))]
     public void TokenWithInValidIssuerValidationFails(ProtocolVersion version, Purpose purpose)
     {
         var validationParameters = new PasetoTokenValidationParameters()
@@ -115,14 +86,7 @@ public sealed class PasetoValidationTest
     }
 
     [Theory(DisplayName = "Should succeed on token with valid subject")]
-    [InlineData(ProtocolVersion.V1, Purpose.Local)]
-    [InlineData(ProtocolVersion.V1, Purpose.Public)]
-    [InlineData(ProtocolVersion.V2, Purpose.Local)]
-    [InlineData(ProtocolVersion.V2, Purpose.Public)]
-    [InlineData(ProtocolVersion.V3, Purpose.Local)]
-    [InlineData(ProtocolVersion.V3, Purpose.Public)]
-    [InlineData(ProtocolVersion.V4, Purpose.Local)]
-    [InlineData(ProtocolVersion.V4, Purpose.Public)]
+    [MemberData(nameof(TestHelper.AllVersionsAndPurposesData), MemberType = typeof(TestHelper))]
     public void TokenWithValidSubjectValidationSucceeds(ProtocolVersion version, Purpose purpose)
     {
         var validationParameters = new PasetoTokenValidationParameters()
@@ -141,14 +105,7 @@ public sealed class PasetoValidationTest
     }
 
     [Theory(DisplayName = "Should fail on token with invalid subject")]
-    [InlineData(ProtocolVersion.V1, Purpose.Local)]
-    [InlineData(ProtocolVersion.V1, Purpose.Public)]
-    [InlineData(ProtocolVersion.V2, Purpose.Local)]
-    [InlineData(ProtocolVersion.V2, Purpose.Public)]
-    [InlineData(ProtocolVersion.V3, Purpose.Local)]
-    [InlineData(ProtocolVersion.V3, Purpose.Public)]
-    [InlineData(ProtocolVersion.V4, Purpose.Local)]
-    [InlineData(ProtocolVersion.V4, Purpose.Public)]
+    [MemberData(nameof(TestHelper.AllVersionsAndPurposesData), MemberType = typeof(TestHelper))]
     public void TokenWithInValidSubjectValidationFails(ProtocolVersion version, Purpose purpose)
     {
         var validationParameters = new PasetoTokenValidationParameters()

--- a/tests/Paseto.Tests/TestHelper.cs
+++ b/tests/Paseto.Tests/TestHelper.cs
@@ -1,5 +1,7 @@
 ﻿namespace Paseto.Tests;
 
+using System;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 
@@ -8,6 +10,8 @@ using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.Pkcs;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.OpenSsl;
+using Paseto.Extensions;
+using Xunit;
 
 public static class TestHelper
 {
@@ -96,4 +100,30 @@ public static class TestHelper
 
         return CryptoBytes.FromHexString(key);
     }
+
+    public static TheoryData<ProtocolVersion, Purpose> AllVersionsAndPurposesData()
+    {
+        var ret = new TheoryData<ProtocolVersion, Purpose>();
+
+        foreach (var version in Enum.GetValues<ProtocolVersion>())
+        foreach (var purpose in Enum.GetValues<Purpose>())
+            ret.Add(version, purpose);
+
+        return ret;
+    }
+
+    public static TheoryData<ProtocolVersion> AllVersionsData() =>  Enum.GetValues<ProtocolVersion>()
+        .Aggregate(new TheoryData<ProtocolVersion>(), (x, y) =>
+        {
+            x.Add(y);
+            return x;
+        });
+
+    public static TheoryData<string> VersionStringNameData() =>  Enum.GetValues<ProtocolVersion>()
+        .Select(x => x.ToDescription())
+        .Aggregate(new TheoryData<string>(), (x, y) =>
+        {
+            x.Add(y);
+            return x;
+        });
 }


### PR DESCRIPTION
Replaces a bunch of `InlineData` with `MemberData` that uses `Enum.GetValue<T>` to make adding newer versions less fragile insofar as forgetting to add them to a test.