### PR TITLE
Migrate to BouncyCastle.cryptography

### DIFF
--- a/src/Paseto/Paseto.csproj
+++ b/src/Paseto/Paseto.csproj
@@ -49,7 +49,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NaCl.Core" Version="2.0.5" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup Label="Package References for Windows" Condition=" '$(TargetFramework)' == 'net48' ">

--- a/tests/Paseto.Tests/Paseto.Tests.csproj
+++ b/tests/Paseto.Tests/Paseto.Tests.csproj
@@ -179,7 +179,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.categories" Version="2.0.8" />
     <PackageReference Include="xunit.runner.console" Version="2.8.1">


### PR DESCRIPTION
Portable.BouncyCastle and BouncyCastle.Cryptography are different packages for the same source, so they have overlapping C# namespaces. This makes it impossible to use both even if one is a transitive dependency.

Portable.BouncyCastle is no longer being updated as the authors now publish a Nuget directly. The BouncyCastle site shows BouncyCastle.Cryptography as their official Nuget.

Closes #151 