### PR TITLE
feat: add .NET Framework 4.8 (net48) support

### DIFF
--- a/benchmarks/Paseto.Benchmark/packages.lock.json
+++ b/benchmarks/Paseto.Benchmark/packages.lock.json
@@ -303,6 +303,7 @@
         "dependencies": {
           "BouncyCastle.Cryptography": "[2.6.2, )",
           "Microsoft.NET.Test.Sdk": "[18.7.0, )",
+          "Newtonsoft.Json": "[13.0.3, )",
           "Paseto.Core": "[1.0.0, )",
           "Shouldly": "[4.3.0, )",
           "xunit": "[2.9.3, )",

--- a/build.cake
+++ b/build.cake
@@ -63,6 +63,28 @@ Task("Test")
                 ResultsDirectory = $"{artifactsDirectory}/TestResults",
                 Settings = "CodeCoverage.runsettings"
             });
+
+        // The net48 target can only be executed on Windows (there is no .NET Framework
+        // runtime on Linux/macOS). This is the security gate for the net48 code paths.
+        if (IsRunningOnWindows())
+        {
+            DotNetTest(
+                project.ToString(),
+                new DotNetTestSettings()
+                {
+                    Blame = true,
+                    Configuration = configuration,
+                    Framework = "net48",
+                    Loggers = new string[]
+                    {
+                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.net48.trx",
+                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.net48.html",
+                    },
+                    NoBuild = true,
+                    NoRestore = true,
+                    ResultsDirectory = $"{artifactsDirectory}/TestResults",
+                });
+        }
     });
 
 Task("CoverageReport")

--- a/src/Paseto/Extensions/RSAKeyExtensions.cs
+++ b/src/Paseto/Extensions/RSAKeyExtensions.cs
@@ -127,32 +127,32 @@ public static class RSAKeyExtensions
 
         public string Exponent { get; set; }
 
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER || NETFRAMEWORK
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 #endif
         public string P { get; set; }
 
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER || NETFRAMEWORK
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 #endif
         public string Q { get; set; }
 
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER || NETFRAMEWORK
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 #endif
         public string DP { get; set; }
 
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER || NETFRAMEWORK
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 #endif
         public string DQ { get; set; }
 
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER || NETFRAMEWORK
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 #endif
         public string InverseQ { get; set; }
 
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER || NETFRAMEWORK
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 #endif
         public string D { get; set; }

--- a/src/Paseto/Internal/CryptoBytes.cs
+++ b/src/Paseto/Internal/CryptoBytes.cs
@@ -20,9 +20,29 @@ internal static class CryptoBytes
     }
 
     internal static bool ConstantTimeEquals(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y)
-        => x.Length != y.Length
-            ? throw new ArgumentException("x.Length must equal y.Length")
-            : CryptographicOperations.FixedTimeEquals(x, y);
+    {
+        if (x.Length != y.Length)
+            throw new ArgumentException("x.Length must equal y.Length");
+
+#if NETFRAMEWORK
+        // CryptographicOperations.FixedTimeEquals is unavailable on .NET Framework; use a
+        // branch-free bit-difference accumulator that runs in time independent of the data.
+        return InternalConstantTimeEquals(x, y) != 0;
+#else
+        return CryptographicOperations.FixedTimeEquals(x, y);
+#endif
+    }
+
+#if NETFRAMEWORK
+    private static uint InternalConstantTimeEquals(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y)
+    {
+        var differentbits = 0;
+        for (var i = 0; i < x.Length; i++)
+            differentbits |= x[i] ^ y[i];
+
+        return 1 & (unchecked((uint)differentbits - 1) >> 8);
+    }
+#endif
 
     internal static void Wipe(byte[] data)
     {
@@ -46,6 +66,15 @@ internal static class CryptoBytes
     // * Swap files and error dumps can contain secret information
     //   It seems possible to lock memory in RAM, no idea about error dumps
     // CryptographicOperations.ZeroMemory guarantees the write is not elided by the JIT.
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void InternalWipe(byte[] data, int offset, int count) => CryptographicOperations.ZeroMemory(data.AsSpan(offset, count));
+    // On .NET Framework that API is unavailable, so we clear the array on a method flagged
+    // NoInlining | NoOptimization so the JIT cannot drop the wipe as a dead store.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    private static void InternalWipe(byte[] data, int offset, int count)
+    {
+#if NETFRAMEWORK
+        Array.Clear(data, offset, count);
+#else
+        CryptographicOperations.ZeroMemory(data.AsSpan(offset, count));
+#endif
+    }
 }

--- a/src/Paseto/Internal/Guard.cs
+++ b/src/Paseto/Internal/Guard.cs
@@ -1,0 +1,23 @@
+namespace Paseto.Internal;
+
+using System;
+
+/// <summary>
+/// Argument validation helpers that work uniformly across target frameworks.
+/// </summary>
+internal static class Guard
+{
+    /// <summary>
+    /// Throws <see cref="ArgumentNullException"/> if <paramref name="argument"/> is <c>null</c>.
+    /// Mirrors <c>ArgumentNullException.ThrowIfNull</c>, which is only available on .NET 6+.
+    /// </summary>
+    internal static void NotNull(object argument, string paramName)
+    {
+#if NETFRAMEWORK
+        if (argument is null)
+            throw new ArgumentNullException(paramName);
+#else
+        ArgumentNullException.ThrowIfNull(argument, paramName);
+#endif
+    }
+}

--- a/src/Paseto/Internal/Hkdf.cs
+++ b/src/Paseto/Internal/Hkdf.cs
@@ -1,0 +1,49 @@
+namespace Paseto.Internal;
+
+using System;
+using System.Security.Cryptography;
+#if NETFRAMEWORK
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+#endif
+
+/// <summary>
+/// HKDF (RFC 5869) key derivation that works uniformly across target frameworks.
+/// <para>
+/// The BCL <see cref="HKDF"/> type is only available on .NET 5+. On .NET Framework the equivalent
+/// primitive from BouncyCastle (<c>HkdfBytesGenerator</c>) is used, which is byte-for-byte
+/// interoperable with the BCL implementation for the same inputs.
+/// </para>
+/// </summary>
+internal static class Hkdf
+{
+    /// <summary>
+    /// Derives <paramref name="outputLength"/> bytes of key material from <paramref name="ikm"/>.
+    /// A <c>null</c> <paramref name="salt"/> is treated as a zero-filled salt of the hash length,
+    /// matching both RFC 5869 and the BCL/BouncyCastle behavior.
+    /// </summary>
+    internal static byte[] DeriveKey(HashAlgorithmName hashAlgorithmName, byte[] ikm, int outputLength, byte[] info = null, byte[] salt = null)
+    {
+#if NETFRAMEWORK
+        var hkdf = new HkdfBytesGenerator(DigestFor(hashAlgorithmName));
+        hkdf.Init(new HkdfParameters(ikm, salt, info));
+        var okm = new byte[outputLength];
+        hkdf.GenerateBytes(okm, 0, outputLength);
+        return okm;
+#else
+        return HKDF.DeriveKey(hashAlgorithmName, ikm, outputLength, salt, info);
+#endif
+    }
+
+#if NETFRAMEWORK
+    private static IDigest DigestFor(HashAlgorithmName name)
+    {
+        if (name == HashAlgorithmName.SHA384) return new Sha384Digest();
+        if (name == HashAlgorithmName.SHA256) return new Sha256Digest();
+        if (name == HashAlgorithmName.SHA512) return new Sha512Digest();
+        throw new NotSupportedException($"Hash algorithm {name} is not supported for HKDF.");
+    }
+#endif
+}

--- a/src/Paseto/Internal/IsExternalInit.cs
+++ b/src/Paseto/Internal/IsExternalInit.cs
@@ -1,0 +1,14 @@
+#if NETFRAMEWORK
+namespace System.Runtime.CompilerServices;
+
+using System.ComponentModel;
+
+/// <summary>
+/// Polyfill that lets the C# compiler emit <c>init</c>-only property setters when targeting
+/// .NET Framework, which does not ship the <see cref="IsExternalInit"/> type in its BCL.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class IsExternalInit
+{
+}
+#endif

--- a/src/Paseto/Internal/NullableAttributes.cs
+++ b/src/Paseto/Internal/NullableAttributes.cs
@@ -1,0 +1,12 @@
+#if NETFRAMEWORK
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Polyfill for the nullable-analysis attribute, which exists only as an internal type in the
+/// .NET Framework BCL and is therefore inaccessible to consuming code.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+internal sealed class NotNullAttribute : Attribute
+{
+}
+#endif

--- a/src/Paseto/Internal/Pbkdf2.cs
+++ b/src/Paseto/Internal/Pbkdf2.cs
@@ -1,0 +1,44 @@
+namespace Paseto.Internal;
+
+using System;
+using System.Security.Cryptography;
+#if NETFRAMEWORK
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+#endif
+
+/// <summary>
+/// PBKDF2 (RFC 2898) key derivation that works uniformly across target frameworks.
+/// <para>
+/// The static <see cref="Rfc2898DeriveBytes.Pbkdf2(byte[], byte[], int, HashAlgorithmName, int)"/>
+/// overload is only available on .NET 6+. On .NET Framework the equivalent BouncyCastle primitive
+/// (<c>Pkcs5S2ParametersGenerator</c>) is used, which produces identical output for the same inputs.
+/// </para>
+/// </summary>
+internal static class Pbkdf2
+{
+    /// <summary>Derives <paramref name="outputLength"/> bytes using PBKDF2.</summary>
+    internal static byte[] DeriveBytes(byte[] password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithmName, int outputLength)
+    {
+#if NETFRAMEWORK
+        var generator = new Pkcs5S2ParametersGenerator(DigestFor(hashAlgorithmName));
+        generator.Init(password, salt, iterations);
+        var keyParam = (KeyParameter)generator.GenerateDerivedMacParameters(outputLength * 8);
+        return keyParam.GetKey();
+#else
+        return Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithmName, outputLength);
+#endif
+    }
+
+#if NETFRAMEWORK
+    private static IDigest DigestFor(HashAlgorithmName name)
+    {
+        if (name == HashAlgorithmName.SHA384) return new Sha384Digest();
+        if (name == HashAlgorithmName.SHA256) return new Sha256Digest();
+        if (name == HashAlgorithmName.SHA512) return new Sha512Digest();
+        throw new NotSupportedException($"Hash algorithm {name} is not supported for PBKDF2.");
+    }
+#endif
+}

--- a/src/Paseto/Internal/Rng.cs
+++ b/src/Paseto/Internal/Rng.cs
@@ -1,0 +1,38 @@
+namespace Paseto.Internal;
+
+using System.Security.Cryptography;
+
+/// <summary>
+/// Cryptographically secure random byte generation that works uniformly across target frameworks.
+/// <para>
+/// The static <see cref="RandomNumberGenerator"/> convenience methods (<c>Fill</c>, <c>GetBytes</c>)
+/// were introduced in .NET Core / .NET 6+ and do not exist on .NET Framework. On .NET Framework the
+/// instance API (<see cref="RandomNumberGenerator.Create()"/>) is used, which is equally a CSPRNG.
+/// </para>
+/// </summary>
+internal static class Rng
+{
+    /// <summary>Fills <paramref name="data"/> with cryptographically strong random bytes.</summary>
+    internal static void Fill(byte[] data)
+    {
+#if NETFRAMEWORK
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(data);
+#else
+        RandomNumberGenerator.Fill(data);
+#endif
+    }
+
+    /// <summary>Returns a new array of <paramref name="count"/> cryptographically strong random bytes.</summary>
+    internal static byte[] GetBytes(int count)
+    {
+#if NETFRAMEWORK
+        var data = new byte[count];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(data);
+        return data;
+#else
+        return RandomNumberGenerator.GetBytes(count);
+#endif
+    }
+}

--- a/src/Paseto/Internal/RuntimeHelpers.cs
+++ b/src/Paseto/Internal/RuntimeHelpers.cs
@@ -1,0 +1,28 @@
+#if NETFRAMEWORK
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Polyfill supplying the <c>GetSubArray</c> helper the C# compiler emits when an array is sliced
+/// with a range (e.g. <c>array[a..b]</c>). .NET Framework's <see cref="RuntimeHelpers"/> does not
+/// include this method, so range-based array slicing does not compile without it.
+/// </summary>
+/// <remarks>
+/// This type intentionally shadows the BCL <c>RuntimeHelpers</c> for this assembly's compilation
+/// (compiler warning CS0436); it is only referenced by the compiler for array range slicing, which
+/// the BCL type cannot satisfy on this framework.
+/// </remarks>
+internal static class RuntimeHelpers
+{
+    public static T[] GetSubArray<T>(T[] array, Range range)
+    {
+        var (offset, length) = range.GetOffsetAndLength(array.Length);
+
+        if (length == 0)
+            return Array.Empty<T>();
+
+        var dest = new T[length];
+        Array.Copy(array, offset, dest, 0, length);
+        return dest;
+    }
+}
+#endif

--- a/src/Paseto/Paserk.cs
+++ b/src/Paseto/Paserk.cs
@@ -4,6 +4,7 @@ using System;
 using System.Text.RegularExpressions;
 using Paseto.Cryptography.Key;
 using Paseto.Extensions;
+using Paseto.Internal;
 
 /// <summary>
 /// PASERK (Platform-Agnostic Serialized Keys) extension.
@@ -87,8 +88,8 @@ public static class Paserk
     /// <returns>The encoded serialized key in PASERK format.</returns>
     public static string Encode(PasetoKey pasetoKey, PaserkType type, PasetoSymmetricKey wrappingKey)
     {
-        ArgumentNullException.ThrowIfNull(pasetoKey);
-        ArgumentNullException.ThrowIfNull(wrappingKey);
+        Guard.NotNull(pasetoKey, nameof(pasetoKey));
+        Guard.NotNull(wrappingKey, nameof(wrappingKey));
 
         if (type is not (PaserkType.LocalWrap or PaserkType.SecretWrap))
             throw new PaserkNotSupportedException($"The PASERK type {type} does not support key wrapping.");
@@ -112,7 +113,7 @@ public static class Paserk
     /// <param name="wrappingKey">The symmetric key used to unwrap the serialized key.</param>
     public static PasetoKey Decode(string serializedKey, PasetoSymmetricKey wrappingKey)
     {
-        ArgumentNullException.ThrowIfNull(wrappingKey);
+        Guard.NotNull(wrappingKey, nameof(wrappingKey));
 
         var (type, version, header, encodedKey) = ParseHeader(serializedKey);
 
@@ -137,7 +138,7 @@ public static class Paserk
     /// <returns>The encoded serialized key in PASERK format.</returns>
     public static string Encode(PasetoKey pasetoKey, PaserkType type, ReadOnlySpan<byte> password, PbkwOptions options = null)
     {
-        ArgumentNullException.ThrowIfNull(pasetoKey);
+        Guard.NotNull(pasetoKey, nameof(pasetoKey));
 
         if (type is not (PaserkType.LocalPassword or PaserkType.SecretPassword))
             throw new PaserkNotSupportedException($"The PASERK type {type} does not support password-based wrapping.");
@@ -177,8 +178,8 @@ public static class Paserk
     /// <returns>The encoded serialized key in PASERK format.</returns>
     public static string Encode(PasetoKey pasetoKey, PaserkType type, PasetoAsymmetricPublicKey sealingKey)
     {
-        ArgumentNullException.ThrowIfNull(pasetoKey);
-        ArgumentNullException.ThrowIfNull(sealingKey);
+        Guard.NotNull(pasetoKey, nameof(pasetoKey));
+        Guard.NotNull(sealingKey, nameof(sealingKey));
 
         if (type is not PaserkType.Seal)
             throw new PaserkNotSupportedException($"The PASERK type {type} does not support sealing.");
@@ -201,7 +202,7 @@ public static class Paserk
     /// <param name="sealingKey">The recipient's asymmetric secret key.</param>
     public static PasetoKey Decode(string serializedKey, PasetoAsymmetricSecretKey sealingKey)
     {
-        ArgumentNullException.ThrowIfNull(sealingKey);
+        Guard.NotNull(sealingKey, nameof(sealingKey));
 
         var (type, version, header, encodedKey) = ParseHeader(serializedKey);
 

--- a/src/Paseto/PaserkPbkw.cs
+++ b/src/Paseto/PaserkPbkw.cs
@@ -69,8 +69,8 @@ internal static class PaserkPbkw
     private static string EncryptArgon(string header, byte[] password, PbkwOptions options, byte[] ptk)
     {
         var h = GetBytes(header);
-        var s = RandomNumberGenerator.GetBytes(ARGON_SALT_SIZE);
-        var n = RandomNumberGenerator.GetBytes(XCHACHA_NONCE_SIZE);
+        var s = Rng.GetBytes(ARGON_SALT_SIZE);
+        var n = Rng.GetBytes(XCHACHA_NONCE_SIZE);
 
         var k = Argon2id(password, s, options.MemoryLimitBytes, options.OpsLimit, options.Parallelism);
         try
@@ -144,11 +144,11 @@ internal static class PaserkPbkw
     private static string EncryptPbkdf2(string header, byte[] password, PbkwOptions options, byte[] ptk)
     {
         var h = GetBytes(header);
-        var s = RandomNumberGenerator.GetBytes(PBKDF2_SALT_SIZE);
-        var n = RandomNumberGenerator.GetBytes(AES_NONCE_SIZE);
+        var s = Rng.GetBytes(PBKDF2_SALT_SIZE);
+        var n = Rng.GetBytes(AES_NONCE_SIZE);
         var i = options.Iterations;
 
-        var k = Rfc2898DeriveBytes.Pbkdf2(password, s, i, HashAlgorithmName.SHA384, PREKEY_SIZE);
+        var k = Pbkdf2.DeriveBytes(password, s, i, HashAlgorithmName.SHA384, PREKEY_SIZE);
         try
         {
             var ek = Sha384(DOMAIN_ENCRYPTION, k)[..32];
@@ -186,7 +186,7 @@ internal static class PaserkPbkw
         var n = body[nOffset..(nOffset + AES_NONCE_SIZE)];
         var edk = body[(nOffset + AES_NONCE_SIZE)..];
 
-        var k = Rfc2898DeriveBytes.Pbkdf2(password, s, i, HashAlgorithmName.SHA384, PREKEY_SIZE);
+        var k = Pbkdf2.DeriveBytes(password, s, i, HashAlgorithmName.SHA384, PREKEY_SIZE);
         try
         {
             var ak = Sha384(DOMAIN_AUTHENTICATION, k);

--- a/src/Paseto/PaserkPie.cs
+++ b/src/Paseto/PaserkPie.cs
@@ -43,7 +43,7 @@ internal static class PaserkPie
     internal static string Wrap(string header, ProtocolVersion version, byte[] wk, byte[] ptk)
     {
         var h = GetBytes(header);
-        var n = RandomNumberGenerator.GetBytes(NONCE_SIZE);
+        var n = Rng.GetBytes(NONCE_SIZE);
 
         return version switch
         {

--- a/src/Paseto/PaserkSeal.cs
+++ b/src/Paseto/PaserkSeal.cs
@@ -75,7 +75,7 @@ internal static class PaserkSeal
         var xpk = Ed25519PublicKeyToX25519(edPublicKey);
 
         // Ephemeral X25519 keypair.
-        var esk = RandomNumberGenerator.GetBytes(X25519_KEY_SIZE);
+        var esk = Rng.GetBytes(X25519_KEY_SIZE);
         var epk = new byte[X25519_KEY_SIZE];
         X25519.ScalarMultBase(esk, 0, epk, 0);
 
@@ -323,7 +323,12 @@ internal static class PaserkSeal
     /// </summary>
     private static byte[] Ed25519SeedToX25519(byte[] seed)
     {
+#if NETFRAMEWORK
+        using var sha512 = SHA512.Create();
+        var h = sha512.ComputeHash(seed);
+#else
         var h = SHA512.HashData(seed);
+#endif
         var xsk = h[..X25519_KEY_SIZE];
         xsk[0] &= 248;
         xsk[31] &= 127;

--- a/src/Paseto/Paseto.csproj
+++ b/src/Paseto/Paseto.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -57,9 +57,12 @@
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References for Windows" Condition=" '$(TargetFramework)' == 'net48' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+  <!-- Lets the net48 target compile on non-Windows machines (macOS/Linux CI). -->
+  <ItemGroup Label="Package References" Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="IndexRange" Version="1.1.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 
   <Target Name="Versioning" BeforeTargets="MinVer">

--- a/src/Paseto/Protocol/PasetoProtocolVersion.cs
+++ b/src/Paseto/Protocol/PasetoProtocolVersion.cs
@@ -56,7 +56,7 @@ public abstract class PasetoProtocolVersion
         }
 
         var n = new byte[size];
-        RandomNumberGenerator.Fill(n);
+        Rng.Fill(n);
         return n;
     }
 

--- a/src/Paseto/Protocol/Version1.cs
+++ b/src/Paseto/Protocol/Version1.cs
@@ -9,6 +9,10 @@ using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
+#if NETFRAMEWORK
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+#endif
 
 using Paseto.Cryptography.Key;
 using Paseto.Extensions;
@@ -58,7 +62,7 @@ public class Version1 : PasetoProtocolVersion, IPasetoProtocolVersion
     public virtual PasetoSymmetricKey GenerateSymmetricKey()
     {
         var n = new byte[SYM_KEY_SIZE_IN_BYTES];
-        RandomNumberGenerator.Fill(n);
+        Rng.Fill(n);
 
         return new PasetoSymmetricKey(n, this);
     }
@@ -70,10 +74,26 @@ public class Version1 : PasetoProtocolVersion, IPasetoProtocolVersion
     /// <returns><see cref="Paseto.Cryptography.Key.PasetoAsymmetricKeyPair" /></returns>
     public virtual PasetoAsymmetricKeyPair GenerateAsymmetricKeyPair(byte[] seed = null)
     {
+#if NETFRAMEWORK
+        // RSA.ExportRSAPrivateKey/ExportRSAPublicKey (PKCS#1 DER) are .NET Core 3.0+ only.
+        // Generate with BouncyCastle and emit the same PKCS#1 structures that Sign/Verify parse.
+        var generator = new RsaKeyPairGenerator();
+        generator.Init(new KeyGenerationParameters(new SecureRandom(), ASYM_KEY_SIZE_IN_BITS));
+        var keyPair = generator.GenerateKeyPair();
+
+        var priv = (RsaPrivateCrtKeyParameters)keyPair.Private;
+        var pub = (RsaKeyParameters)keyPair.Public;
+
+        var sk = new RsaPrivateKeyStructure(priv.Modulus, priv.PublicExponent, priv.Exponent, priv.P, priv.Q, priv.DP, priv.DQ, priv.QInv)
+            .ToAsn1Object().GetDerEncoded();
+        var pk = new RsaPublicKeyStructure(pub.Modulus, pub.Exponent)
+            .ToAsn1Object().GetDerEncoded();
+#else
         using var rsa = RSA.Create();
         rsa.KeySize = ASYM_KEY_SIZE_IN_BITS;
         var sk = rsa.ExportRSAPrivateKey();
         var pk = rsa.ExportRSAPublicKey();
+#endif
 
         return new PasetoAsymmetricKeyPair(sk, pk, this);
     }
@@ -160,8 +180,8 @@ public class Version1 : PasetoProtocolVersion, IPasetoProtocolVersion
         var nonce = hmacn.ComputeHash(m)[..SYM_NONCE_SIZE_IN_BYTES];
 
         // Split the key into an Encryption key and Authentication key
-        var ek = HKDF.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), SYM_KEYDERIVATION_SIZE_IN_BYTES, info: GetBytes(EK_DOMAIN_SEPARATION), salt: nonce[..SYM_NONCE_SPLIT_SIZE_IN_BYTES]);
-        var ak = HKDF.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), SYM_KEYDERIVATION_SIZE_IN_BYTES, info: GetBytes(AK_DOMAIN_SEPARATION), salt: nonce[..SYM_NONCE_SPLIT_SIZE_IN_BYTES]);
+        var ek = Hkdf.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), SYM_KEYDERIVATION_SIZE_IN_BYTES, info: GetBytes(EK_DOMAIN_SEPARATION), salt: nonce[..SYM_NONCE_SPLIT_SIZE_IN_BYTES]);
+        var ak = Hkdf.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), SYM_KEYDERIVATION_SIZE_IN_BYTES, info: GetBytes(AK_DOMAIN_SEPARATION), salt: nonce[..SYM_NONCE_SPLIT_SIZE_IN_BYTES]);
 
         try
         {
@@ -278,8 +298,8 @@ public class Version1 : PasetoProtocolVersion, IPasetoProtocolVersion
             var t = bytes[tlen..];
 
             // Split the key into an Encryption key and Authentication key
-            var ek = HKDF.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), SYM_KEYDERIVATION_SIZE_IN_BYTES, info: GetBytes(EK_DOMAIN_SEPARATION), salt: n[..SYM_NONCE_SPLIT_SIZE_IN_BYTES].ToArray());
-            var ak = HKDF.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), SYM_KEYDERIVATION_SIZE_IN_BYTES, info: GetBytes(AK_DOMAIN_SEPARATION), salt: n[..SYM_NONCE_SPLIT_SIZE_IN_BYTES].ToArray());
+            var ek = Hkdf.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), SYM_KEYDERIVATION_SIZE_IN_BYTES, info: GetBytes(EK_DOMAIN_SEPARATION), salt: n[..SYM_NONCE_SPLIT_SIZE_IN_BYTES].ToArray());
+            var ak = Hkdf.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), SYM_KEYDERIVATION_SIZE_IN_BYTES, info: GetBytes(AK_DOMAIN_SEPARATION), salt: n[..SYM_NONCE_SPLIT_SIZE_IN_BYTES].ToArray());
 
             try
             {

--- a/src/Paseto/Protocol/Version2.cs
+++ b/src/Paseto/Protocol/Version2.cs
@@ -50,7 +50,7 @@ public class Version2 : PasetoProtocolVersion, IPasetoProtocolVersion
     public virtual PasetoSymmetricKey GenerateSymmetricKey()
     {
         var n = new byte[KEY_SIZE_IN_BYTES];
-        RandomNumberGenerator.Fill(n);
+        Rng.Fill(n);
 
         return new PasetoSymmetricKey(n, this);
     }

--- a/src/Paseto/Protocol/Version3.cs
+++ b/src/Paseto/Protocol/Version3.cs
@@ -67,7 +67,7 @@ public class Version3 : PasetoProtocolVersion, IPasetoProtocolVersion
     public virtual PasetoSymmetricKey GenerateSymmetricKey()
     {
         var n = new byte[KEY_SIZE_IN_BYTES];
-        RandomNumberGenerator.Fill(n);
+        Rng.Fill(n);
 
         return new PasetoSymmetricKey(n, this);
     }
@@ -175,11 +175,11 @@ public class Version3 : PasetoProtocolVersion, IPasetoProtocolVersion
         var n = GetRandomBytes(NONCE_SIZE_IN_BYTES);
 
         // Split the key into an Encryption key and Authentication key
-        var tmp = HKDF.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), KEYDERIVATION_SIZE_IN_BYTES, info: CryptoBytes.Combine(GetBytes(EK_DOMAIN_SEPARATION), n));
+        var tmp = Hkdf.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), KEYDERIVATION_SIZE_IN_BYTES, info: CryptoBytes.Combine(GetBytes(EK_DOMAIN_SEPARATION), n));
         var ek = tmp[..32];
         var n2 = tmp[32..];
 
-        var ak = HKDF.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), KEYDERIVATION_SIZE_IN_BYTES, info: CryptoBytes.Combine(GetBytes(AK_DOMAIN_SEPARATION), n));
+        var ak = Hkdf.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), KEYDERIVATION_SIZE_IN_BYTES, info: CryptoBytes.Combine(GetBytes(AK_DOMAIN_SEPARATION), n));
 
         try
         {
@@ -316,11 +316,11 @@ public class Version3 : PasetoProtocolVersion, IPasetoProtocolVersion
             var t = bytes[tlen..];
 
             // Split the key into an Encryption key and Authentication key
-            var tmp = HKDF.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), KEYDERIVATION_SIZE_IN_BYTES, info: CryptoBytes.Combine(GetBytes(EK_DOMAIN_SEPARATION), n.ToArray()));
+            var tmp = Hkdf.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), KEYDERIVATION_SIZE_IN_BYTES, info: CryptoBytes.Combine(GetBytes(EK_DOMAIN_SEPARATION), n.ToArray()));
             var ek = tmp[..32];
             var n2 = tmp[32..];
 
-            var ak = HKDF.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), KEYDERIVATION_SIZE_IN_BYTES, info: CryptoBytes.Combine(GetBytes(AK_DOMAIN_SEPARATION), n.ToArray()));
+            var ak = Hkdf.DeriveKey(HashAlgorithmName.SHA384, pasetoKey.Key.ToArray(), KEYDERIVATION_SIZE_IN_BYTES, info: CryptoBytes.Combine(GetBytes(AK_DOMAIN_SEPARATION), n.ToArray()));
 
             try
             {

--- a/src/Paseto/Protocol/Version4.cs
+++ b/src/Paseto/Protocol/Version4.cs
@@ -50,7 +50,7 @@ public class Version4 : PasetoProtocolVersion, IPasetoProtocolVersion
     public virtual PasetoSymmetricKey GenerateSymmetricKey()
     {
         var n = new byte[KEY_SIZE_IN_BYTES];
-        RandomNumberGenerator.Fill(n);
+        Rng.Fill(n);
 
         return new PasetoSymmetricKey(n, this);
     }

--- a/src/Paseto/Utils/Base64UrlEncoder.cs
+++ b/src/Paseto/Utils/Base64UrlEncoder.cs
@@ -42,7 +42,12 @@ public class Base64UrlEncoder : IBase64UrlEncoder
     /// <returns>Base64Url encoding of the UTF8 bytes.</returns>
     public string Encode(ReadOnlySpan<byte> input, PaddingPolicy policy = PaddingPolicy.Discard)
     {
+#if NETFRAMEWORK
+        // .NET Framework has no ReadOnlySpan<byte> overload of Convert.ToBase64String.
+        var encoded = Convert.ToBase64String(input.ToArray()).Replace(Char62, UrlChar62).Replace(Char63, UrlChar63);
+#else
         var encoded = Convert.ToBase64String(input).Replace(Char62, UrlChar62).Replace(Char63, UrlChar63);
+#endif
         if (policy == PaddingPolicy.Discard)
             encoded = encoded.TrimEnd(OnePads);
 

--- a/src/Paseto/Utils/EncodingHelper.cs
+++ b/src/Paseto/Utils/EncodingHelper.cs
@@ -120,7 +120,13 @@ internal static class EncodingHelper
     /// </summary>
     /// <param name="input">The input.</param>
     /// <returns>System.String.</returns>
-    internal static string GetString(ReadOnlySpan<byte> input) => Encoding.UTF8.GetString(input);
+    internal static string GetString(ReadOnlySpan<byte> input)
+#if NETFRAMEWORK
+        // .NET Framework has no ReadOnlySpan<byte> overload of Encoding.GetString.
+        => Encoding.UTF8.GetString(input.ToArray());
+#else
+        => Encoding.UTF8.GetString(input);
+#endif
 
     /// <summary>
     /// Base64 URL safe encoding.

--- a/src/Paseto/packages.lock.json
+++ b/src/Paseto/packages.lock.json
@@ -1,6 +1,179 @@
 {
   "version": 1,
   "dependencies": {
+    ".NETFramework,Version=v4.8": {
+      "BouncyCastle.Cryptography": {
+        "type": "Direct",
+        "requested": "[2.6.2, )",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "IndexRange": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "nTESnAJi+itrCESxerrN33q8JYUIRueRzMSM6ogUbds88YyhOGd38DXLkCMjDoBlYn13DmB+AYKMA+ETEz/4EQ==",
+        "dependencies": {
+          "Microsoft.Bcl.Memory": "9.0.14"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[10.0.300, )",
+        "resolved": "10.0.300",
+        "contentHash": "QzCtLkXVb3l4IxcpvJCbzUwMLihAmLN6vVLjQGSzYSF8d2dvXxqJAZk83RV3gYnp2egz8jRMgSR2woY3vOahTA==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "10.0.300",
+          "Microsoft.SourceLink.Common": "10.0.300",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
+      "MinVer": {
+        "type": "Direct",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "2lMTCQl5bGP4iv0JNkockPnyllC6eHLz+CoK2ICvalvHod+exXSxueu9hq+zNkU7bZBJf8wMfeRC/Edn8AGmEg=="
+      },
+      "NaCl.Core": {
+        "type": "Direct",
+        "requested": "[2.2.0, )",
+        "resolved": "2.2.0",
+        "contentHash": "oDMMcIxu2INIz/GsHRmMEsua5DDFLSW2OIel9R/UsJZ2a8tD2TEdbtDsFp+GbD3w/VXQjc/P9Dubtoi0450SZQ==",
+        "dependencies": {
+          "IndexRange": "1.1.1",
+          "System.Memory": "4.6.3"
+        }
+      },
+      "System.Memory": {
+        "type": "Direct",
+        "requested": "[4.6.3, )",
+        "resolved": "4.6.3",
+        "contentHash": "qdcDOgnFZY40+Q9876JUHnlHu7bosOHX8XISRoH94fwk6hgaeQGSgfZd8srWRZNt5bV9ZW2TljcegDNxsf+96A==",
+        "dependencies": {
+          "System.Buffers": "4.6.1",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Direct",
+        "requested": "[9.0.9, )",
+        "resolved": "9.0.9",
+        "contentHash": "NEnpppwq67fRz/OvQRxsEMgetDJsxlxpEsAFO/4PZYbAyAMd4Ol6KS7phc8uDoKPsnbdzRLKobpX303uQwCqdg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.9",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.9",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.9",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "HVLnwIccvmsAySQM8N8q468DA/W/OddDB6deWXZDF0VPOwZ0utnm0aErfX4LnNVnsThtoPyVH0kCPPcitGcUdQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.Bcl.Memory": {
+        "type": "Transitive",
+        "resolved": "9.0.14",
+        "contentHash": "laQCcjTM2FnbyznkAu9hwBuQh3z2/OtJKwjGkJOUevylFpFXZIUVq/+MU2jM0HQm1n5wsjjwtLIDOiWJ6Nai3A==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "10.0.300",
+        "contentHash": "P0kaQwVZx4xIUe2FtrLyBadYNXuAljttJUPvjBYRuHhPE8L77L42KakLDkaADRiUrGspoLcMwayjrbQhYTr0zA==",
+        "dependencies": {
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "10.0.300",
+        "contentHash": "0jlkXaUGjYlWTIVPve5MftjKHnT3SlAtq9BCLV4J9IjdPrxV/+4rMlBSjfr1khG8/GC6KGojjola8E1VvWF0qQ=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.6.1",
+        "contentHash": "N8GXpmiLMtljq7gwvyS+1QvKT/W2J8sNAvx+HVg4NGmsG/H+2k/y9QI23auLJRterrzCiDH+IWAw4V/GPwsMlw=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "+dJsbPJ3FyUbTZNplFj0RCKePFizmv6ewDV46JE9q/IVH4c3xTCftHfHelLsAKf0jryIPqgMb5GpS0x7TAY3mg==",
+        "dependencies": {
+          "System.Buffers": "4.6.1",
+          "System.Memory": "4.6.3"
+        }
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "VySjpsCLprojvat550Flrm3NQB982CPuDzILajqjQihFmrQXZPdQyktIbcpVPJyaExFYtAfY1DpwMdWQuS0kbw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.6.1",
+        "contentHash": "sQxefTnhagrhoq2ReR0D/6K0zJcr9Hrd6kikeXsA1I8kOCboTavcUC4r7TSfpKFeE163uMuxZcyfO1mGO3EN8Q=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.1.2",
+        "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "bzYTmAcmfelUOCBxvbgsfSr2tq94ydA2gJZAxZRcuNa0LlmlVz8JNHst6RG1qsDujyVYT4vjv06y8sCLbvCXdg==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
+      }
+    },
     "net10.0": {
       "BouncyCastle.Cryptography": {
         "type": "Direct",

--- a/tests/Paseto.Tests/PaserkTests.cs
+++ b/tests/Paseto.Tests/PaserkTests.cs
@@ -12,7 +12,6 @@ using Newtonsoft.Json;
 using Paseto.Extensions;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Categories;
 
 using Org.BouncyCastle.Crypto.Parameters;
 
@@ -22,7 +21,7 @@ using Paseto.Internal;
 
 using static Paseto.Tests.TestHelper;
 
-[Category("CI")]
+[Trait("Category", "CI")]
 public class PaserkTests
 {
     private readonly ITestOutputHelper _output;

--- a/tests/Paseto.Tests/PaserkTests.cs
+++ b/tests/Paseto.Tests/PaserkTests.cs
@@ -29,7 +29,7 @@ public class PaserkTests
 
     public PaserkTests(ITestOutputHelper output) => _output = output;
 
-    private static readonly ProtocolVersion[] ValidProtocols = Enum.GetValues<ProtocolVersion>();
+    private static readonly ProtocolVersion[] ValidProtocols = ((ProtocolVersion[])Enum.GetValues(typeof(ProtocolVersion)));
 
     private static readonly PaserkType[] SupportedPaserkTypes =
     [

--- a/tests/Paseto.Tests/Paseto.Tests.csproj
+++ b/tests/Paseto.Tests/Paseto.Tests.csproj
@@ -5,8 +5,6 @@
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <!-- Xunit.Categories 3.x is not strong-named; suppress the signed-reference warning -->
-    <NoWarn>$(NoWarn);CS8002</NoWarn>
     <Authors>David De Smet</Authors>
     <Copyright>Copyright © 2018-2024 David De Smet</Copyright>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
@@ -189,7 +187,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.categories" Version="3.0.1" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Paseto.Tests/Paseto.Tests.csproj
+++ b/tests/Paseto.Tests/Paseto.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -185,6 +185,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
+    <!-- Used by the test-vector models; transitive on modern TFMs but must be explicit for net48. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.categories" Version="3.0.1" />
@@ -202,9 +204,12 @@
     <ProjectReference Include="..\..\src\Paseto\Paseto.csproj" />
   </ItemGroup>
 
+  <!-- Lets the net48 target compile on non-Windows machines (macOS/Linux CI). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="IndexRange" Version="1.1.1" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/tests/Paseto.Tests/PasetoBuilderTests.cs
+++ b/tests/Paseto.Tests/PasetoBuilderTests.cs
@@ -126,7 +126,7 @@ public class PasetoBuilderTests
     public void ShouldSucceedOnGenerateAsymmetricKeyPairWhenSeedIsProvided(ProtocolVersion version, int secretKeyLength, int publicKeyLength)
     {
         var seed = new byte[32];
-        RandomNumberGenerator.Fill(seed);
+        using (var rng = RandomNumberGenerator.Create()) rng.GetBytes(seed);
 
         var pasetoKey = new PasetoBuilder().Use(version, Purpose.Public)
                                            .GenerateAsymmetricKeyPair(seed);
@@ -490,7 +490,7 @@ public class PasetoBuilderTests
         };
 
         var key = new byte[keyLength];
-        RandomNumberGenerator.Fill(key);
+        using (var rng = RandomNumberGenerator.Create()) rng.GetBytes(key);
 
         var parsek = new PasetoBuilder().Use(version, Purpose.Public)
             .WithKey(key, Encryption.AsymmetricPublicKey)
@@ -514,7 +514,7 @@ public class PasetoBuilderTests
         };
 
         var key = new byte[keyLength];
-        RandomNumberGenerator.Fill(key);
+        using (var rng = RandomNumberGenerator.Create()) rng.GetBytes(key);
 
         var parsek = new PasetoBuilder().Use(version, Purpose.Public)
             .WithKey(key, Encryption.AsymmetricSecretKey)
@@ -598,7 +598,7 @@ public class PasetoBuilderTests
         };
 
         var sharedKey = new byte[keyLength];
-        RandomNumberGenerator.Fill(sharedKey);
+        using (var rng = RandomNumberGenerator.Create()) rng.GetBytes(sharedKey);
 
         var keyPair = new PasetoBuilder()
             .Use(version, purpose)
@@ -695,7 +695,7 @@ public class PasetoBuilderTests
 
         var ret = new TheoryData<ProtocolVersion, byte[]>();
 
-        foreach (var version in Enum.GetValues<ProtocolVersion>())
+        foreach (var version in ((ProtocolVersion[])Enum.GetValues(typeof(ProtocolVersion))))
         foreach (var key in bytes)
             ret.Add(version, key);
 
@@ -714,7 +714,7 @@ public class PasetoBuilderTests
 
         var ret = new TheoryData<ProtocolVersion, byte[]>();
 
-        foreach (var version in Enum.GetValues<ProtocolVersion>().Where(x => x != ProtocolVersion.V1))
+        foreach (var version in ((ProtocolVersion[])Enum.GetValues(typeof(ProtocolVersion))).Where(x => x != ProtocolVersion.V1))
         foreach (var key in bytes)
             ret.Add(version, key);
 

--- a/tests/Paseto.Tests/PasetoTestVectors.cs
+++ b/tests/Paseto.Tests/PasetoTestVectors.cs
@@ -9,7 +9,6 @@ using Shouldly;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Categories;
 
 using Builder;
 using Cryptography;
@@ -18,7 +17,7 @@ using Vectors;
 
 using static TestHelper;
 
-[Category("CI")]
+[Trait("Category", "CI")]
 public class PasetoTestVectors
 {
     private readonly string[] SKIP_ASSERT_ENCODE = { "v1" };

--- a/tests/Paseto.Tests/TestHelper.cs
+++ b/tests/Paseto.Tests/TestHelper.cs
@@ -11,6 +11,13 @@ using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.OpenSsl;
 using Paseto.Extensions;
 using Xunit;
+#if NETFRAMEWORK
+using System.IO;
+using Org.BouncyCastle.Asn1.Sec;
+using Org.BouncyCastle.Asn1.X9;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+#endif
 
 public static class TestHelper
 {
@@ -65,10 +72,24 @@ public static class TestHelper
 
         if (ECDsaPrivateKeyRegex.IsMatch(key))
         {
+#if NETFRAMEWORK
+            // ECDsa.ImportFromPem/ExportECPrivateKey are .NET Core only. Reproduce the SEC1
+            // ECPrivateKey DER with BouncyCastle (verified byte-identical to ExportECPrivateKey).
+            var ecObj = new PemReader(new StringReader(key)).ReadObject();
+            var ecPriv = (ECPrivateKeyParameters)((AsymmetricCipherKeyPair)ecObj).Private;
+            var ecPub = (ECPublicKeyParameters)((AsymmetricCipherKeyPair)ecObj).Public;
+            var ecStruct = new ECPrivateKeyStructure(
+                ecPriv.Parameters.Curve.FieldSize,
+                ecPriv.D,
+                new DerBitString(ecPub.Q.GetEncoded(false)),
+                new X962Parameters(ecPriv.PublicKeyParamSet));
+            return ecStruct.ToAsn1Object().GetDerEncoded();
+#else
             var ecdsaSecretKey = ECDsa.Create();
             ecdsaSecretKey.ImportFromPem(key);
             var sk = ecdsaSecretKey.ExportECPrivateKey();
             return sk;
+#endif
 
             /*
             using var ms = new MemoryStream(GetBytes(key));
@@ -102,34 +123,37 @@ public static class TestHelper
 
         if (RsaPrivateKeyRegex.IsMatch(key))
         {
+#if NETFRAMEWORK
+            // Reproduce ExportRSAPrivateKey (PKCS#1 RSAPrivateKey DER) with BouncyCastle.
+            var rsaObj = new PemReader(new StringReader(key)).ReadObject();
+            var rsaPriv = (RsaPrivateCrtKeyParameters)((AsymmetricCipherKeyPair)rsaObj).Private;
+            return new RsaPrivateKeyStructure(rsaPriv.Modulus, rsaPriv.PublicExponent, rsaPriv.Exponent, rsaPriv.P, rsaPriv.Q, rsaPriv.DP, rsaPriv.DQ, rsaPriv.QInv)
+                .ToAsn1Object().GetDerEncoded();
+#else
             var rsaSecretKey = RSA.Create();
-#if NET5_0_OR_GREATER
             rsaSecretKey.ImportFromPem(key);
-#elif NETCOREAPP3_1
-            var privateKeyBase64 = RsaPrivateKeyRegex.Replace(key, "");
-            var privateKey = Convert.FromBase64String(privateKeyBase64);
-            rsaSecretKey.ImportRSAPrivateKey(new ReadOnlySpan<byte>(privateKey), out _);
-#endif
 
             //var sk = rsaSecretKey.ToCompatibleXmlString(true);
             //return GetBytes(sk);
             return rsaSecretKey.ExportRSAPrivateKey();
+#endif
         }
 
         if (RsaPublicKeyRegex.IsMatch(key))
         {
+#if NETFRAMEWORK
+            // Reproduce ExportRSAPublicKey (PKCS#1 RSAPublicKey DER) from the SPKI PEM with BouncyCastle.
+            var rsaPubObj = (RsaKeyParameters)new PemReader(new StringReader(key)).ReadObject();
+            return new RsaPublicKeyStructure(rsaPubObj.Modulus, rsaPubObj.Exponent)
+                .ToAsn1Object().GetDerEncoded();
+#else
             var rsaPublicKey = RSA.Create();
-#if NET5_0_OR_GREATER
             rsaPublicKey.ImportFromPem(key);
-#elif NETCOREAPP3_1
-            var publicKeyBase64 = RsaPublicKeyRegex.Replace(key, "");
-            var publicKey = Convert.FromBase64String(publicKeyBase64);
-            rsaPublicKey.ImportRSAPublicKey(new ReadOnlySpan<byte>(publicKey), out _);
-#endif
 
             //var pk = rsaPublicKey.ToCompatibleXmlString(false);
             //return GetBytes(pk);
             return rsaPublicKey.ExportRSAPublicKey();
+#endif
         }
 
         return FromHexString(key);
@@ -139,21 +163,21 @@ public static class TestHelper
     {
         var ret = new TheoryData<ProtocolVersion, Purpose>();
 
-        foreach (var version in Enum.GetValues<ProtocolVersion>())
-        foreach (var purpose in Enum.GetValues<Purpose>())
+        foreach (var version in ((ProtocolVersion[])Enum.GetValues(typeof(ProtocolVersion))))
+        foreach (var purpose in ((Purpose[])Enum.GetValues(typeof(Purpose))))
             ret.Add(version, purpose);
 
         return ret;
     }
 
-    public static TheoryData<ProtocolVersion> AllVersionsData() =>  Enum.GetValues<ProtocolVersion>()
+    public static TheoryData<ProtocolVersion> AllVersionsData() =>  ((ProtocolVersion[])Enum.GetValues(typeof(ProtocolVersion)))
         .Aggregate(new TheoryData<ProtocolVersion>(), (x, y) =>
         {
             x.Add(y);
             return x;
         });
 
-    public static TheoryData<string> VersionStringNameData() =>  Enum.GetValues<ProtocolVersion>()
+    public static TheoryData<string> VersionStringNameData() =>  ((ProtocolVersion[])Enum.GetValues(typeof(ProtocolVersion)))
         .Select(x => x.ToDescription())
         .Aggregate(new TheoryData<string>(), (x, y) =>
         {

--- a/tests/Paseto.Tests/packages.lock.json
+++ b/tests/Paseto.Tests/packages.lock.json
@@ -86,15 +86,6 @@
           "xunit.core": "[2.9.3]"
         }
       },
-      "xunit.categories": {
-        "type": "Direct",
-        "requested": "[3.0.1, )",
-        "resolved": "3.0.1",
-        "contentHash": "je4ogEoneIl21pqiGPPF1iWFUP1UKV+//clBmBpJikZXapcoUH6CjEu1YOVSGkmfrpg1wWxmlXew2wfAkqOuGQ==",
-        "dependencies": {
-          "xunit.core": "2.4.1"
-        }
-      },
       "xunit.runner.console": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -374,15 +365,6 @@
           "xunit.core": "[2.9.3]"
         }
       },
-      "xunit.categories": {
-        "type": "Direct",
-        "requested": "[3.0.1, )",
-        "resolved": "3.0.1",
-        "contentHash": "je4ogEoneIl21pqiGPPF1iWFUP1UKV+//clBmBpJikZXapcoUH6CjEu1YOVSGkmfrpg1wWxmlXew2wfAkqOuGQ==",
-        "dependencies": {
-          "xunit.core": "2.4.1"
-        }
-      },
       "xunit.runner.console": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -548,15 +530,6 @@
           "xunit.analyzers": "1.18.0",
           "xunit.assert": "2.9.3",
           "xunit.core": "[2.9.3]"
-        }
-      },
-      "xunit.categories": {
-        "type": "Direct",
-        "requested": "[3.0.1, )",
-        "resolved": "3.0.1",
-        "contentHash": "je4ogEoneIl21pqiGPPF1iWFUP1UKV+//clBmBpJikZXapcoUH6CjEu1YOVSGkmfrpg1wWxmlXew2wfAkqOuGQ==",
-        "dependencies": {
-          "xunit.core": "2.4.1"
         }
       },
       "xunit.runner.console": {

--- a/tests/Paseto.Tests/packages.lock.json
+++ b/tests/Paseto.Tests/packages.lock.json
@@ -1,6 +1,323 @@
 {
   "version": 1,
   "dependencies": {
+    ".NETFramework,Version=v4.8": {
+      "BouncyCastle.Cryptography": {
+        "type": "Direct",
+        "requested": "[2.6.2, )",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
+      "coverlet.msbuild": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "kb5kBe1HioGuH+ZDKysv/oAO9cCUW2yxtrGrRBZp/dIij5f011OfC4XiNMayZ8bGfOv2+n2ocPkaJIGppAZDEg=="
+      },
+      "IndexRange": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "nTESnAJi+itrCESxerrN33q8JYUIRueRzMSM6ogUbds88YyhOGd38DXLkCMjDoBlYn13DmB+AYKMA+ETEz/4EQ==",
+        "dependencies": {
+          "Microsoft.Bcl.Memory": "9.0.14"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.7.0"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0",
+          "Microsoft.CSharp": "4.7.0"
+        }
+      },
+      "System.Memory": {
+        "type": "Direct",
+        "requested": "[4.6.3, )",
+        "resolved": "4.6.3",
+        "contentHash": "qdcDOgnFZY40+Q9876JUHnlHu7bosOHX8XISRoH94fwk6hgaeQGSgfZd8srWRZNt5bV9ZW2TljcegDNxsf+96A==",
+        "dependencies": {
+          "System.Buffers": "4.6.1",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.categories": {
+        "type": "Direct",
+        "requested": "[3.0.1, )",
+        "resolved": "3.0.1",
+        "contentHash": "je4ogEoneIl21pqiGPPF1iWFUP1UKV+//clBmBpJikZXapcoUH6CjEu1YOVSGkmfrpg1wWxmlXew2wfAkqOuGQ==",
+        "dependencies": {
+          "xunit.core": "2.4.1"
+        }
+      },
+      "xunit.runner.console": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "und5dhnsamWN02uVAJeORz4Ny2FK5pxVuchFa416pI7y8rjZxfuiSrvZRUFHNVIVtT7cibOm66bsZHLw5jSSkw=="
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.13.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "HVLnwIccvmsAySQM8N8q468DA/W/OddDB6deWXZDF0VPOwZ0utnm0aErfX4LnNVnsThtoPyVH0kCPPcitGcUdQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.Bcl.Memory": {
+        "type": "Transitive",
+        "resolved": "9.0.14",
+        "contentHash": "laQCcjTM2FnbyznkAu9hwBuQh3z2/OtJKwjGkJOUevylFpFXZIUVq/+MU2jM0HQm1n5wsjjwtLIDOiWJ6Nai3A==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.13.0",
+        "contentHash": "bt0E0Dx+iqW97o4A59RCmUmz/5NarJ7LRL+jXbSHod72ibL5XdNm1Ke+UO5tFhBG4VwHLcSjqq9BUSblGNWamw==",
+        "dependencies": {
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "NaCl.Core": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "oDMMcIxu2INIz/GsHRmMEsua5DDFLSW2OIel9R/UsJZ2a8tD2TEdbtDsFp+GbD3w/VXQjc/P9Dubtoi0450SZQ==",
+        "dependencies": {
+          "IndexRange": "1.1.1",
+          "System.Memory": "4.6.3"
+        }
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.6.1",
+        "contentHash": "N8GXpmiLMtljq7gwvyS+1QvKT/W2J8sNAvx+HVg4NGmsG/H+2k/y9QI23auLJRterrzCiDH+IWAw4V/GPwsMlw=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.5.0",
+        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "VySjpsCLprojvat550Flrm3NQB982CPuDzILajqjQihFmrQXZPdQyktIbcpVPJyaExFYtAfY1DpwMdWQuS0kbw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.6.1",
+        "contentHash": "sQxefTnhagrhoq2ReR0D/6K0zJcr9Hrd6kikeXsA1I8kOCboTavcUC4r7TSfpKFeE163uMuxZcyfO1mGO3EN8Q=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.1.2",
+        "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "bzYTmAcmfelUOCBxvbgsfSr2tq94ydA2gJZAxZRcuNa0LlmlVz8JNHst6RG1qsDujyVYT4vjv06y8sCLbvCXdg==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.9",
+        "contentHash": "NEnpppwq67fRz/OvQRxsEMgetDJsxlxpEsAFO/4PZYbAyAMd4Ol6KS7phc8uDoKPsnbdzRLKobpX303uQwCqdg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.9",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.9",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.9",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "Paseto.Core": {
+        "type": "Project",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "[2.6.2, )",
+          "IndexRange": "[1.1.1, )",
+          "NaCl.Core": "[2.2.0, )",
+          "System.Memory": "[4.6.3, )",
+          "System.Text.Json": "[9.0.9, )"
+        }
+      }
+    },
     "net10.0": {
       "BouncyCastle.Cryptography": {
         "type": "Direct",
@@ -29,6 +346,12 @@
           "Microsoft.CodeCoverage": "18.7.0",
           "Microsoft.TestPlatform.TestHost": "18.7.0"
         }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "Shouldly": {
         "type": "Direct",
@@ -109,11 +432,6 @@
         "type": "Transitive",
         "resolved": "2.2.0",
         "contentHash": "oDMMcIxu2INIz/GsHRmMEsua5DDFLSW2OIel9R/UsJZ2a8tD2TEdbtDsFp+GbD3w/VXQjc/P9Dubtoi0450SZQ=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -205,6 +523,12 @@
           "Microsoft.TestPlatform.TestHost": "18.7.0"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
       "Shouldly": {
         "type": "Direct",
         "requested": "[4.3.0, )",
@@ -284,11 +608,6 @@
         "type": "Transitive",
         "resolved": "2.2.0",
         "contentHash": "oDMMcIxu2INIz/GsHRmMEsua5DDFLSW2OIel9R/UsJZ2a8tD2TEdbtDsFp+GbD3w/VXQjc/P9Dubtoi0450SZQ=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "System.CodeDom": {
         "type": "Transitive",


### PR DESCRIPTION
## What

Re-adds `net48` as a target framework for `Paseto.Core` (now `net48;net8.0;net10.0`), so the library can be consumed from legacy .NET Framework 4.8 apps. Closes #<issue>.

## Why

A user asked whether net48 could be supported. It can — net48 was targeted before and dropped around `78ee106`. Both crypto dependencies (`NaCl.Core`, `BouncyCastle.Cryptography`) support netstandard2.0, so they run on net48.

## How

Six BCL crypto/encoding APIs used by the library don't exist on net48 and are reimplemented behind `#if NETFRAMEWORK`, backed by BouncyCastle (already a dependency):

| Modern API | net48 replacement |
| --- | --- |
| `HKDF.DeriveKey` | `HkdfBytesGenerator` (`Internal/Hkdf.cs`) |
| `Rfc2898DeriveBytes.Pbkdf2` | `Pkcs5S2ParametersGenerator` (`Internal/Pbkdf2.cs`) |
| `RandomNumberGenerator.Fill/GetBytes` | `RandomNumberGenerator.Create()` (`Internal/Rng.cs`) |
| `CryptographicOperations.FixedTimeEquals` | constant-time bit-diff loop (`Internal/CryptoBytes.cs`) |
| `CryptographicOperations.ZeroMemory` | `Array.Clear` under `[NoInlining\|NoOptimization]` |
| `RSA.ExportRSAPrivateKey/PublicKey` | BouncyCastle PKCS#1 export (`Protocol/Version1.cs`) |

Plus compiler/BCL polyfills for net48: `IsExternalInit` (init setters), `RuntimeHelpers.GetSubArray` (array range slicing), `NotNullAttribute`, `Guard.NotNull`, and span/`HashData` fallbacks in `Base64UrlEncoder`, `EncodingHelper`, and `PaserkSeal`.

net48-only packages: `System.Memory`, `IndexRange`, `System.Text.Json`, and `Microsoft.NETFramework.ReferenceAssemblies` (lets net48 compile on Linux/macOS CI runners). The test project also multi-targets net48 (`ReadKey` PEM handling rewritten with BouncyCastle), and `build.cake` runs the net48 test suite on the Windows runner — the runtime security gate.

## Verification

- ✅ net8 suite: **521/521 pass** — refactor is regression-free
- ✅ Source + tests build across all three TFMs in Release
- ✅ Every net48 crypto shim proven **byte-identical** to the BCL API it replaces (HKDF-SHA384, PBKDF2-SHA384, constant-time equals, `GetSubArray`, RSA PKCS#1 keygen/export, and `ReadKey` for EC / RSA-private / RSA-public, checked against the real PASETO test-vector PEMs)
- ⚠️ net48 tests execute only on Windows (no .NET Framework runtime on Linux/macOS); the CI Windows runner is the gate. Byte-equivalence was verified locally to de-risk that run

Closes #99 